### PR TITLE
feat: log and view blocked registrations, refactor SFS client

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -4,7 +4,7 @@ on: [workflow_dispatch, push, pull_request]
 
 jobs:
   run:
-    uses: flarum/framework/.github/workflows/REUSABLE_backend.yml@main
+    uses: flarum/framework/.github/workflows/REUSABLE_backend.yml@1.x
     with:
       enable_backend_testing: true
       enable_phpstan: true

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -4,7 +4,7 @@ on: [workflow_dispatch, push, pull_request]
 
 jobs:
   run:
-    uses: flarum/framework/.github/workflows/REUSABLE_frontend.yml@main
+    uses: flarum/framework/.github/workflows/REUSABLE_frontend.yml@1.x
     with:
       enable_bundlewatch: false
       enable_prettier: true

--- a/extend.php
+++ b/extend.php
@@ -30,7 +30,8 @@ return [
 
     (new Extend\Routes('api'))
         ->post('/users/{id}/spamblock', 'users.spamblock', Api\Controllers\MarkAsSpammerController::class)
-        ->get('/blocked-registrations', 'fof-anti-spam.blocked-registrations.index', Api\Controllers\ListBlockedRegistrationsController::class),
+        ->get('/blocked-registrations', 'fof-anti-spam.blocked-registrations.index', Api\Controllers\ListBlockedRegistrationsController::class)
+        ->delete('/blocked-registrations/{id}', 'fof-anti-spam.blocked-registrations.delete', Api\Controllers\DeleteBlockedRegistrationController::class),
 
     (new Extend\ApiSerializer(ForumSerializer::class))
         ->attributes(Api\AddForumAttributes::class),

--- a/extend.php
+++ b/extend.php
@@ -29,7 +29,8 @@ return [
     new Extend\Locales(__DIR__.'/locale'),
 
     (new Extend\Routes('api'))
-        ->post('/users/{id}/spamblock', 'users.spamblock', Api\Controllers\MarkAsSpammerController::class),
+        ->post('/users/{id}/spamblock', 'users.spamblock', Api\Controllers\MarkAsSpammerController::class)
+        ->get('/blocked-registrations', 'fof-anti-spam.blocked-registrations.index', Api\Controllers\ListBlockedRegistrationsController::class),
 
     (new Extend\ApiSerializer(ForumSerializer::class))
         ->attributes(Api\AddForumAttributes::class),

--- a/extend.php
+++ b/extend.php
@@ -55,7 +55,7 @@ return [
         ->default('fof-anti-spam.email', true)
         ->default('fof-anti-spam.emailhash', false)
         ->default('fof-anti-spam.frequency', 5)
-        ->default('fof-anti-spam.confidence', 50.0)
+        ->default('fof-anti-spam.confidence', 70.0)
         ->default('fof-anti-spam.actions.deleteUser', false)
         ->default('fof-anti-spam.actions.deletePosts', false)
         ->default('fof-anti-spam.actions.deleteDiscussions', false)

--- a/extend.php
+++ b/extend.php
@@ -61,4 +61,7 @@ return [
         ->default('fof-anti-spam.actions.deletePosts', false)
         ->default('fof-anti-spam.actions.deleteDiscussions', false)
         ->default('fof-anti-spam.reportToStopForumSpam', true),
+
+    (new Extend\ServiceProvider())
+        ->register(Providers\SfsProvider::class),
 ];

--- a/js/src/admin/components/AntiSpamSettingsPage.tsx
+++ b/js/src/admin/components/AntiSpamSettingsPage.tsx
@@ -12,7 +12,7 @@ import fullTime from 'flarum/common/helpers/fullTime';
 export default class AntiSpamSettingsPage extends ExtensionPage {
   page!: string;
   blockedLoading: boolean = false;
-  blockedRegistrations: BlockedRegistration[] | null = null;
+  blockedRegistrations: BlockedRegistration[] | null | undefined = null;
 
   oninit(vnode: any) {
     super.oninit(vnode);

--- a/js/src/admin/components/AntiSpamSettingsPage.tsx
+++ b/js/src/admin/components/AntiSpamSettingsPage.tsx
@@ -203,42 +203,12 @@ export default class AntiSpamSettingsPage extends ExtensionPage {
           {!this.blockedLoading && this.blockedRegistrations && this.blockedRegistrations.length > 0 && (
             <div>
               <p className="helpText">{app.translator.trans('fof-anti-spam.admin.blocked_registrations.help')}</p>
-              <div className="BlockedRegistrationsModal-list">
+              <div className="BlockedRegistrations--list">
                 {this.blockedRegistrations.map((blockedRegistration) => {
                   return (
-                    <div className="BlockedRegistrationsModal-item">
-                      <div className="BlockedRegistrationsModal-item-details">
-                        <LabelValue
-                          label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.attempted-at')}
-                          value={fullTime(blockedRegistration.attemptedAt() ?? new Date())}
-                        />
-                        <LabelValue label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.ip')} value={blockedRegistration.ip()} />
-                        <LabelValue
-                          label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.email')}
-                          value={blockedRegistration.email()}
-                        />
-                        <LabelValue
-                          label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.username')}
-                          value={blockedRegistration.username()}
-                        />
-                        {blockedRegistration.provider() && (
-                          <LabelValue
-                            label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.login-provider')}
-                            value={blockedRegistration.provider()}
-                          />
-                        )}
-                        {blockedRegistration.providerData() && (
-                          <LabelValue
-                            label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.login-provider-data')}
-                            value={blockedRegistration.providerData()}
-                          />
-                        )}
-                        <LabelValue
-                          label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.sfs-data')}
-                          value={blockedRegistration.sfsData()}
-                        />
-                      </div>
-                      <div className="BlockedRegistrationsModal-item-actions">{this.actionItems(blockedRegistration).toArray()}</div>
+                    <div className="BlockedRegistrations--item">
+                      <div className="BlockedRegistrations-item--details">{this.detailItems(blockedRegistration).toArray()}</div>
+                      <div className="BlockedRegistrations-item--actions">{this.actionItems(blockedRegistration).toArray()}</div>
                     </div>
                   );
                 })}
@@ -258,8 +228,78 @@ export default class AntiSpamSettingsPage extends ExtensionPage {
     m.redraw();
   }
 
+  detailItems(blockedRegistration: BlockedRegistration): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    items.add(
+      'attemptedAt',
+      <LabelValue
+        label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.attempted-at')}
+        value={fullTime(blockedRegistration.attemptedAt() ?? new Date())}
+      />,
+      100
+    );
+
+    items.add('ip', <LabelValue label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.ip')} value={blockedRegistration.ip()} />, 90);
+
+    items.add(
+      'email',
+      <LabelValue label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.email')} value={blockedRegistration.email()} />,
+      80
+    );
+
+    items.add(
+      'username',
+      <LabelValue label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.username')} value={blockedRegistration.username()} />,
+      70
+    );
+
+    blockedRegistration.provider() &&
+      items.add(
+        'provider',
+        <LabelValue
+          label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.login-provider')}
+          value={blockedRegistration.provider()}
+        />,
+        60
+      );
+
+    blockedRegistration.providerData() &&
+      items.add(
+        'providerData',
+        <LabelValue
+          label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.login-provider-data')}
+          value={blockedRegistration.providerData()}
+        />,
+        50
+      );
+
+    items.add(
+      'sfsData',
+      <LabelValue label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.sfs-data')} value={blockedRegistration.sfsData()} />,
+      20
+    );
+
+    return items;
+  }
+
   actionItems(blockedRegistration: BlockedRegistration): ItemList<Mithril.Children> {
     const items = new ItemList<Mithril.Children>();
+
+    items.add(
+      'delete',
+      <Button
+        className="Button Button--danger"
+        icon="fas fa-trash"
+        onclick={() => {
+          blockedRegistration.delete();
+          this.blockedRegistrations = this.blockedRegistrations?.filter((b) => b.id() !== blockedRegistration.id());
+          m.redraw();
+        }}
+      >
+        {app.translator.trans('fof-anti-spam.admin.blocked_registrations.delete_entry')}
+      </Button>
+    );
 
     return items;
   }

--- a/js/src/admin/components/AntiSpamSettingsPage.tsx
+++ b/js/src/admin/components/AntiSpamSettingsPage.tsx
@@ -1,137 +1,266 @@
 import app from 'flarum/admin/app';
 import ExtensionPage from 'flarum/admin/components/ExtensionPage';
+import Button from 'flarum/common/components/Button';
 import Link from 'flarum/common/components/Link';
+import type Mithril from 'mithril';
+import LoadingIndicator from 'flarum/common/components/LoadingIndicator';
+import BlockedRegistration from '../../common/models/BlockedRegistration';
+import ItemList from 'flarum/common/utils/ItemList';
+import LabelValue from 'flarum/common/components/LabelValue';
+import fullTime from 'flarum/common/helpers/fullTime';
 
 export default class AntiSpamSettingsPage extends ExtensionPage {
+  page!: string;
+  blockedLoading: boolean = false;
+  blockedRegistrations: BlockedRegistration[] | null = null;
+
+  oninit(vnode: any) {
+    super.oninit(vnode);
+
+    this.page = 'settings';
+  }
+
   content() {
+    return (
+      <div className="FoFAntiSpamSettings">
+        <div className="container">
+          {this.menuButtons()}
+          {this.page === 'settings' && this.settingsContent()}
+          {this.page === 'blocked-registrations' && this.blockedRegistrationsContent()}
+        </div>
+      </div>
+    );
+  }
+
+  menuButtons(): Mithril.Children {
+    return (
+      <div className="MenuButtons">
+        <Button className={`Button ${this.page === 'settings' ? 'active' : ''}`} icon="fas fa-cog" onclick={() => this.setPage('settings')}>
+          {app.translator.trans('fof-anti-spam.admin.settings.button')}
+        </Button>
+        <Button
+          className={`Button ${this.page === 'blocked-registrations' ? 'active' : ''}`}
+          icon="fas fa-ban"
+          onclick={() => this.setPage('blocked-registrations')}
+        >
+          {app.translator.trans('fof-anti-spam.admin.blocked_registrations.button')}
+        </Button>
+      </div>
+    );
+  }
+
+  setPage(page: string): void {
+    this.page = page;
+
+    if (page === 'blocked-registrations' && !this.blockedRegistrations) {
+      this.loadData();
+    } else {
+      m.redraw();
+    }
+  }
+
+  settingsContent(): Mithril.Children {
     const apiRegions = ['closest', 'europe', 'us'];
     const tagsEnabled = app.initializers.has('flarum-tags');
 
     return (
-      <div className="FoFAntiSpamSettings">
-        <div className="container">
-          <div className="Form">
-            <div className="Section Section--defaultActions">
-              <h3>{app.translator.trans('fof-anti-spam.admin.settings.default-actions.heading')}</h3>
-              <p className="helpText">{app.translator.trans('fof-anti-spam.admin.settings.default-actions.introduction')}</p>
-              {this.buildSettingComponent({
-                type: 'boolean',
-                setting: 'fof-anti-spam.actions.deleteUser',
-                label: app.translator.trans('fof-anti-spam.admin.settings.default-actions.delete_user_label'),
-                help: app.translator.trans('fof-anti-spam.admin.settings.default-actions.delete_user_help'),
-              })}
-              {this.buildSettingComponent({
-                type: 'boolean',
-                setting: 'fof-anti-spam.actions.deletePosts',
-                label: app.translator.trans('fof-anti-spam.admin.settings.default-actions.delete_posts_label'),
-                help: app.translator.trans('fof-anti-spam.admin.settings.default-actions.delete_posts_help'),
-              })}
-              {this.buildSettingComponent({
-                type: 'boolean',
-                setting: 'fof-anti-spam.actions.deleteDiscussions',
-                label: app.translator.trans('fof-anti-spam.admin.settings.default-actions.delete_discussions_label'),
-                help: app.translator.trans('fof-anti-spam.admin.settings.default-actions.delete_discussions_help'),
-              })}
-              {tagsEnabled &&
-                this.buildSettingComponent({
-                  type: 'flarum-tags.select-tags',
-                  setting: 'fof-anti-spam.actions.moveDiscussionsToTags',
-                  label: app.translator.trans('fof-anti-spam.admin.settings.default-actions.move_discussions_to_tags_label'),
-                  help: app.translator.trans('fof-anti-spam.admin.settings.default-actions.move_discussions_to_tags_help'),
-                  options: {
-                    requireParentTag: true,
-                    limits: {
-                      max: {
-                        primary: 1,
-                      },
-                      min: {
-                        primary: 1,
-                      },
+      <div className="FoFAntiSpamSettings--settings">
+        <div className="Form">
+          <div className="Section Section--defaultActions">
+            <h3>{app.translator.trans('fof-anti-spam.admin.settings.default-actions.heading')}</h3>
+            <p className="helpText">{app.translator.trans('fof-anti-spam.admin.settings.default-actions.introduction')}</p>
+            {this.buildSettingComponent({
+              type: 'boolean',
+              setting: 'fof-anti-spam.actions.deleteUser',
+              label: app.translator.trans('fof-anti-spam.admin.settings.default-actions.delete_user_label'),
+              help: app.translator.trans('fof-anti-spam.admin.settings.default-actions.delete_user_help'),
+            })}
+            {this.buildSettingComponent({
+              type: 'boolean',
+              setting: 'fof-anti-spam.actions.deletePosts',
+              label: app.translator.trans('fof-anti-spam.admin.settings.default-actions.delete_posts_label'),
+              help: app.translator.trans('fof-anti-spam.admin.settings.default-actions.delete_posts_help'),
+            })}
+            {this.buildSettingComponent({
+              type: 'boolean',
+              setting: 'fof-anti-spam.actions.deleteDiscussions',
+              label: app.translator.trans('fof-anti-spam.admin.settings.default-actions.delete_discussions_label'),
+              help: app.translator.trans('fof-anti-spam.admin.settings.default-actions.delete_discussions_help'),
+            })}
+            {tagsEnabled &&
+              this.buildSettingComponent({
+                type: 'flarum-tags.select-tags',
+                setting: 'fof-anti-spam.actions.moveDiscussionsToTags',
+                label: app.translator.trans('fof-anti-spam.admin.settings.default-actions.move_discussions_to_tags_label'),
+                help: app.translator.trans('fof-anti-spam.admin.settings.default-actions.move_discussions_to_tags_help'),
+                options: {
+                  requireParentTag: true,
+                  limits: {
+                    max: {
+                      primary: 1,
+                    },
+                    min: {
+                      primary: 1,
                     },
                   },
-                })}
-            </div>
-            <div className="Section Section--stopforumspam">
-              <h3>{app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.heading')}</h3>
-              <div className="Introduction">
-                <p className="helpText">
-                  {app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.introduction', {
-                    a: <Link href="https://stopforumspam.com" target="_blank" external={true} />,
-                  })}
-                </p>
-              </div>
-              {this.buildSettingComponent({
-                type: 'select',
-                setting: 'fof-anti-spam.regionalEndpoint',
-                options: apiRegions.reduce((o: { [key: string]: string }, p) => {
-                  o[p] = app.translator.trans(`fof-anti-spam.admin.settings.stopforumspam.region_${p}_label`) as string;
-                  return o;
-                }, {}),
-                label: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.regional_endpoint_label'),
-                help: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.regional_endpoint_help'),
-                default: 'closest',
+                },
               })}
-              {this.buildSettingComponent({
-                type: 'boolean',
-                setting: 'fof-anti-spam.sfs-lookup',
-                label: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.sfs_lookup_label'),
-                help: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.sfs_lookup_help'),
-              })}
-              {this.buildSettingComponent({
-                type: 'boolean',
-                setting: 'fof-anti-spam.username',
-                label: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.username_label'),
-              })}
-              {this.buildSettingComponent({
-                type: 'boolean',
-                setting: 'fof-anti-spam.ip',
-                label: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.ip_label'),
-              })}
-              {this.buildSettingComponent({
-                type: 'boolean',
-                setting: 'fof-anti-spam.email',
-                label: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.email_label'),
-              })}
-              {this.buildSettingComponent({
-                type: 'boolean',
-                setting: 'fof-anti-spam.emailhash',
-                label: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.email_hash_label'),
-                help: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.email_hash_help'),
-              })}
-              {this.buildSettingComponent({
-                type: 'number',
-                setting: 'fof-anti-spam.frequency',
-                label: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.frequency_label'),
-                help: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.frequency_help'),
-                placeholder: '5',
-                required: true,
-              })}
-              {this.buildSettingComponent({
-                type: 'number',
-                setting: 'fof-anti-spam.confidence',
-                label: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.confidence_label'),
-                help: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.confidence_help'),
-                min: 0,
-                max: 100,
-                placeholder: '50.0',
-                required: true,
-              })}
-              <p className="helpText">{app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.api_key_text')}</p>
-              {this.buildSettingComponent({
-                type: 'string',
-                setting: 'fof-anti-spam.api_key',
-                label: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.api_key_label'),
-                help: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.api_key_instructions_text', {
-                  register: <a href="https://www.stopforumspam.com/forum/register.php" />,
-                  key: <a href="https://www.stopforumspam.com/keys" />,
-                }),
-              })}
-            </div>
-            <hr />
-            {this.submitButton()}
           </div>
+          <div className="Section Section--stopforumspam">
+            <h3>{app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.heading')}</h3>
+            <div className="Introduction">
+              <p className="helpText">
+                {app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.introduction', {
+                  a: <Link href="https://stopforumspam.com" target="_blank" external={true} />,
+                })}
+              </p>
+            </div>
+            {this.buildSettingComponent({
+              type: 'select',
+              setting: 'fof-anti-spam.regionalEndpoint',
+              options: apiRegions.reduce((o: { [key: string]: string }, p) => {
+                o[p] = app.translator.trans(`fof-anti-spam.admin.settings.stopforumspam.region_${p}_label`) as string;
+                return o;
+              }, {}),
+              label: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.regional_endpoint_label'),
+              help: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.regional_endpoint_help'),
+              default: 'closest',
+            })}
+            {this.buildSettingComponent({
+              type: 'boolean',
+              setting: 'fof-anti-spam.sfs-lookup',
+              label: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.sfs_lookup_label'),
+              help: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.sfs_lookup_help'),
+            })}
+            {this.buildSettingComponent({
+              type: 'boolean',
+              setting: 'fof-anti-spam.username',
+              label: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.username_label'),
+            })}
+            {this.buildSettingComponent({
+              type: 'boolean',
+              setting: 'fof-anti-spam.ip',
+              label: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.ip_label'),
+            })}
+            {this.buildSettingComponent({
+              type: 'boolean',
+              setting: 'fof-anti-spam.email',
+              label: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.email_label'),
+            })}
+            {this.buildSettingComponent({
+              type: 'boolean',
+              setting: 'fof-anti-spam.emailhash',
+              label: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.email_hash_label'),
+              help: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.email_hash_help'),
+            })}
+            {this.buildSettingComponent({
+              type: 'number',
+              setting: 'fof-anti-spam.frequency',
+              label: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.frequency_label'),
+              help: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.frequency_help'),
+              placeholder: '5',
+              required: true,
+            })}
+            {this.buildSettingComponent({
+              type: 'number',
+              setting: 'fof-anti-spam.confidence',
+              label: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.confidence_label'),
+              help: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.confidence_help'),
+              min: 0,
+              max: 100,
+              placeholder: '50.0',
+              required: true,
+            })}
+            <p className="helpText">{app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.api_key_text')}</p>
+            {this.buildSettingComponent({
+              type: 'string',
+              setting: 'fof-anti-spam.api_key',
+              label: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.api_key_label'),
+              help: app.translator.trans('fof-anti-spam.admin.settings.stopforumspam.api_key_instructions_text', {
+                register: <a href="https://www.stopforumspam.com/forum/register.php" />,
+                key: <a href="https://www.stopforumspam.com/keys" />,
+              }),
+            })}
+          </div>
+          <hr />
+          {this.submitButton()}
         </div>
       </div>
     );
+  }
+
+  blockedRegistrationsContent(): Mithril.Children {
+    return (
+      <div className="FoFAntiSpamSettings--blockedRegistrations">
+        <div className="Form">
+          <h3>{app.translator.trans('fof-anti-spam.admin.blocked_registrations.title')}</h3>
+          {this.blockedLoading && <LoadingIndicator />}
+          {!this.blockedLoading && this.blockedRegistrations && this.blockedRegistrations.length === 0 && (
+            <div>
+              <p>{app.translator.trans('fof-anti-spam.admin.blocked_registrations.no-records')}</p>
+            </div>
+          )}
+          {!this.blockedLoading && this.blockedRegistrations && this.blockedRegistrations.length > 0 && (
+            <div>
+              <p className="helpText">{app.translator.trans('fof-anti-spam.admin.blocked_registrations.help')}</p>
+              <div className="BlockedRegistrationsModal-list">
+                {this.blockedRegistrations.map((blockedRegistration) => {
+                  return (
+                    <div className="BlockedRegistrationsModal-item">
+                      <div className="BlockedRegistrationsModal-item-details">
+                        <LabelValue
+                          label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.attempted-at')}
+                          value={fullTime(blockedRegistration.attemptedAt() ?? new Date())}
+                        />
+                        <LabelValue label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.ip')} value={blockedRegistration.ip()} />
+                        <LabelValue
+                          label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.email')}
+                          value={blockedRegistration.email()}
+                        />
+                        <LabelValue
+                          label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.username')}
+                          value={blockedRegistration.username()}
+                        />
+                        {blockedRegistration.provider() && (
+                          <LabelValue
+                            label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.login-provider')}
+                            value={blockedRegistration.provider()}
+                          />
+                        )}
+                        {blockedRegistration.providerData() && (
+                          <LabelValue
+                            label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.login-provider-data')}
+                            value={blockedRegistration.providerData()}
+                          />
+                        )}
+                        <LabelValue
+                          label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.sfs-data')}
+                          value={blockedRegistration.sfsData()}
+                        />
+                      </div>
+                      <div className="BlockedRegistrationsModal-item-actions">{this.actionItems(blockedRegistration).toArray()}</div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  async loadData() {
+    this.blockedLoading = true;
+    m.redraw();
+    this.blockedRegistrations = await app.store.find<BlockedRegistration[]>('blocked-registrations');
+    this.blockedLoading = false;
+    m.redraw();
+  }
+
+  actionItems(blockedRegistration: BlockedRegistration): ItemList<Mithril.Children> {
+    const items = new ItemList<Mithril.Children>();
+
+    return items;
   }
 }

--- a/js/src/admin/components/AntiSpamSettingsPage.tsx
+++ b/js/src/admin/components/AntiSpamSettingsPage.tsx
@@ -271,50 +271,74 @@ export default class AntiSpamSettingsPage extends ExtensionPage {
 
     items.add(
       'attemptedAt',
-      <LabelValue
-        label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.attempted-at')}
-        value={fullTime(blockedRegistration.attemptedAt() ?? new Date())}
-      />,
+      <div className="BlockedRegistrations-item--details">
+        <span className="BlockedRegistrations-label">{app.translator.trans('fof-anti-spam.admin.blocked_registrations.attempted-at')}</span>
+        <span className="BlockedRegistrations-value">{fullTime(blockedRegistration.attemptedAt() ?? new Date())}</span>
+      </div>,
       100
     );
 
-    items.add('ip', <LabelValue label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.ip')} value={blockedRegistration.ip()} />, 90);
+    items.add(
+      'ip',
+      <div className="BlockedRegistrations-item--details">
+        <span className="BlockedRegistrations-label">{app.translator.trans('fof-anti-spam.admin.blocked_registrations.ip')}</span>
+        <span className="BlockedRegistrations-value">{blockedRegistration.ip()}</span>
+      </div>,
+      90
+    );
 
     items.add(
       'email',
-      <LabelValue label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.email')} value={blockedRegistration.email()} />,
+      <div className="BlockedRegistrations-item--details">
+        <span className="BlockedRegistrations-label">{app.translator.trans('fof-anti-spam.admin.blocked_registrations.email')}</span>
+        <span className="BlockedRegistrations-value">{blockedRegistration.email()}</span>
+      </div>,
       80
     );
 
     items.add(
       'username',
-      <LabelValue label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.username')} value={blockedRegistration.username()} />,
+      <div className="BlockedRegistrations-item--details">
+        <span className="BlockedRegistrations-label">{app.translator.trans('fof-anti-spam.admin.blocked_registrations.username')}</span>
+        <span className="BlockedRegistrations-value">{blockedRegistration.username()}</span>
+      </div>,
       70
     );
 
-    blockedRegistration.provider() &&
+    if (blockedRegistration.provider()) {
       items.add(
         'provider',
-        <LabelValue
-          label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.login-provider')}
-          value={blockedRegistration.provider()}
-        />,
+        <div className="BlockedRegistrations-item--details">
+          <span className="BlockedRegistrations-label">{app.translator.trans('fof-anti-spam.admin.blocked_registrations.login-provider')}</span>
+          <span className="BlockedRegistrations-value">
+            <code>{blockedRegistration.provider()}</code>
+          </span>
+        </div>,
         60
       );
+    }
 
-    blockedRegistration.providerData() &&
+    if (blockedRegistration.providerData()) {
       items.add(
         'providerData',
-        <LabelValue
-          label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.login-provider-data')}
-          value={blockedRegistration.providerData()}
-        />,
+        <div className="BlockedRegistrations-item--details">
+          <span className="BlockedRegistrations-label">{app.translator.trans('fof-anti-spam.admin.blocked_registrations.login-provider-data')}</span>
+          <span className="BlockedRegistrations-value">
+            <code>{blockedRegistration.providerData()}</code>
+          </span>
+        </div>,
         50
       );
+    }
 
     items.add(
       'sfsData',
-      <LabelValue label={app.translator.trans('fof-anti-spam.admin.blocked_registrations.sfs-data')} value={blockedRegistration.sfsData()} />,
+      <div className="BlockedRegistrations-item--details">
+        <span className="BlockedRegistrations-label">{app.translator.trans('fof-anti-spam.admin.blocked_registrations.sfs-data')}</span>
+        <span className="BlockedRegistrations-value">
+          <code>{blockedRegistration.sfsData()}</code>
+        </span>
+      </div>,
       20
     );
 

--- a/js/src/admin/extend.ts
+++ b/js/src/admin/extend.ts
@@ -1,0 +1,4 @@
+import Extend from 'flarum/common/extenders';
+import { default as extend } from '../common/extend';
+
+export default [...extend];

--- a/js/src/admin/index.ts
+++ b/js/src/admin/index.ts
@@ -1,6 +1,8 @@
 import app from 'flarum/admin/app';
 import AntiSpamSettingsPage from './components/AntiSpamSettingsPage';
 
+export { default as extend } from './extend';
+
 app.initializers.add('fof/anti-spam', () => {
   app.extensionData
     .for('fof-anti-spam')

--- a/js/src/common/extend.ts
+++ b/js/src/common/extend.ts
@@ -1,0 +1,7 @@
+import Extend from 'flarum/common/extenders';
+import BlockedRegistration from './models/BlockedRegistration';
+
+export default [
+  new Extend.Store() //
+    .add('blocked-registrations', BlockedRegistration),
+];

--- a/js/src/common/models/BlockedRegistration.tsx
+++ b/js/src/common/models/BlockedRegistration.tsx
@@ -1,0 +1,31 @@
+import Model from 'flarum/common/Model';
+
+export default class BlockedRegistration extends Model {
+  ip() {
+    return Model.attribute<string>('ip').call(this);
+  }
+
+  email() {
+    return Model.attribute<string>('email').call(this);
+  }
+
+  username() {
+    return Model.attribute<string>('username').call(this);
+  }
+
+  sfsData() {
+    return Model.attribute<string>('sfsData').call(this);
+  }
+
+  provider() {
+    return Model.attribute<string | null>('provider').call(this);
+  }
+
+  providerData() {
+    return Model.attribute<string | null>('providerData').call(this);
+  }
+
+  attemptedAt() {
+    return Model.attribute('attemptedAt', Model.transformDate).call(this);
+  }
+}

--- a/js/src/forum/components/HandleSpammerModal.tsx
+++ b/js/src/forum/components/HandleSpammerModal.tsx
@@ -140,6 +140,7 @@ export default class HandleSpammerModal extends Modal<HandleSpammerModalAttrs> {
       .then(() => {
         this.loading = false;
         this.hide();
+        
       });
   }
 }

--- a/js/src/forum/components/HandleSpammerModal.tsx
+++ b/js/src/forum/components/HandleSpammerModal.tsx
@@ -140,7 +140,6 @@ export default class HandleSpammerModal extends Modal<HandleSpammerModalAttrs> {
       .then(() => {
         this.loading = false;
         this.hide();
-        
       });
   }
 }

--- a/js/src/forum/extend.ts
+++ b/js/src/forum/extend.ts
@@ -1,7 +1,11 @@
 import Extend from 'flarum/common/extenders';
 import User from 'flarum/common/models/User';
 
+import { default as extend } from '../common/extend';
+
 export default [
+  ...extend,
+
   new Extend.Model(User) //
     .attribute<boolean>('canSpamblock'),
 ];

--- a/less/admin.less
+++ b/less/admin.less
@@ -1,20 +1,104 @@
 .FoFAntiSpamSettings {
-    padding-top: 20px;
-  
+  padding-top: 20px;
+
+  .Button {
+    margin-right: 10px;
+    margin-bottom: 10px;
+  }
+
+  &--settings {
+    background: @control-bg; // Use control background for coherence
+    padding: 20px;
+    border-radius: @border-radius; // Consistent border radius
+    box-shadow: 0 2px 4px @shadow-color; // Subtle shadow for depth
+    //max-width: 720px;
+    margin: 0 auto; // Center align for better presentation
+
     @media @desktop-up {
-      .container {
-        max-width: 600px;
-        margin: 0;
+      margin: 0;
+    }
+
+    .Section {
+      background: @body-bg; // Contrast with the section background
+      border-radius: @border-radius;
+      box-shadow: 0 1px 3px @shadow-color;
+      padding: 15px;
+      margin-bottom: 20px;
+
+      h3 {
+        color: @primary-color; // Primary color for headings
+        margin-bottom: 10px;
       }
     }
-  
-    fieldset {
-      margin-bottom: 30px;
-  
-      > ul {
-        list-style: none;
-        margin: 0;
-        padding: 0;
+
+    .Form {
+      .control {
+        background: @body-bg;
+        border: 1px solid @muted-color; // Defines the input fields
+        color: @text-color;
+        padding: 6px 12px;
+        border-radius: @border-radius;
+      }
+
+      .Button {
+        background: @primary-color; // Button with primary color
+        color: @body-bg;
+
+        &:hover {
+          background: darken(@primary-color, 5%);
+        }
       }
     }
   }
+
+  &--blockedRegistrations {
+    background: @control-bg; // Use control background for coherence
+    padding: 20px;
+    border-radius: @border-radius; // Consistent border radius
+    box-shadow: 0 2px 4px @shadow-color; // Subtle shadow for depth
+
+    .Form {
+      margin-bottom: 20px;
+    }
+
+    h3 {
+      color: @primary-color; // Primary color for headings
+      margin-bottom: 10px;
+    }
+
+    .BlockedRegistrations--list {
+      .BlockedRegistrations--item {
+        display: flex; // Enable flexbox layout
+        justify-content: space-between; // Space between details and actions
+        align-items: center; // Vertically align the contents
+        background: @body-bg;
+        border-radius: @border-radius;
+        box-shadow: 0 1px 3px @shadow-color;
+        margin-bottom: 10px;
+        padding: 10px;
+        transition: box-shadow 0.3s;
+
+        &:hover {
+          box-shadow: 0 2px 5px @shadow-color;
+        }
+
+        .BlockedRegistrations-item--details {
+          flex-grow: 1; // Allows details to take up the available space
+          padding: 5px;
+          color: @text-color;
+        }
+
+        .BlockedRegistrations-item--actions {
+          // Align the actions to the right
+          padding: 5px;
+          display: flex; // Enable flexbox layout for actions
+          align-items: center; // Vertically align the buttons
+
+          .Button {
+            margin-left: 10px; // Space between buttons
+          }
+        }
+      }
+    }
+  }
+}

--- a/less/admin.less
+++ b/less/admin.less
@@ -68,9 +68,10 @@
 
     .BlockedRegistrations--list {
       .BlockedRegistrations--item {
-        display: flex; // Enable flexbox layout
-        justify-content: space-between; // Space between details and actions
-        align-items: center; // Vertically align the contents
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        gap: 10px;
+        align-items: center;
         background: @body-bg;
         border-radius: @border-radius;
         box-shadow: 0 1px 3px @shadow-color;
@@ -83,20 +84,27 @@
         }
 
         .BlockedRegistrations-item--details {
-          flex-grow: 1; // Allows details to take up the available space
-          padding: 5px;
-          color: @text-color;
+          display: contents;
+
+          .BlockedRegistrations-label {
+            grid-column: 1;
+            font-weight: bold;
+            white-space: nowrap;
+          }
+
+          .BlockedRegistrations-value {
+            grid-column: 2;
+            overflow-wrap: break-word;
+            overflow: auto;
+          }
         }
 
         .BlockedRegistrations-item--actions {
-          // Align the actions to the right
-          padding: 5px;
-          display: flex; // Enable flexbox layout for actions
-          align-items: center; // Vertically align the buttons
-
-          .Button {
-            margin-left: 10px; // Space between buttons
-          }
+          grid-column: 3;
+          grid-row: -1;
+          justify-self: end;
+          display: flex;
+          gap: 10px;
         }
       }
     }

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -70,7 +70,7 @@ fof-anti-spam:
   forum:
     message:
       stopforumspam:
-        blocked: Your registration data has been marked as spam, so you have been prevented from completing your registration. If you believe this is a mistake, please contact the forum administrator.
+        blocked: Details of your registration have been found in a spam prevention database, therefore your registration has been blocked.
     spammer_modal:
       hard_delete_discussions_label: Delete discussions
       hard_delete_discussions_help: This will permanently delete all discussions started by this user. When disabled, discussions will be hidden instead.

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -65,6 +65,7 @@ fof-anti-spam:
       login-provider: Login Provider
       login-provider-data: Login Provider Data
       sfs-data: StopForumSpam Data
+      delete_entry: Delete entry
 
   forum:
     message:

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -69,7 +69,7 @@ fof-anti-spam:
 
   forum:
     message:
-      spam: Your info has been marked as spam.
+      spam: Your registration data has been marked as spam, so you have been prevented from completing your registration. If you believe this is a mistake, please contact the forum administrator.
     spammer_modal:
       hard_delete_discussions_label: Delete discussions
       hard_delete_discussions_help: This will permanently delete all discussions started by this user. When disabled, discussions will be hidden instead.

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -69,7 +69,8 @@ fof-anti-spam:
 
   forum:
     message:
-      spam: Your registration data has been marked as spam, so you have been prevented from completing your registration. If you believe this is a mistake, please contact the forum administrator.
+      stopforumspam:
+        blocked: Your registration data has been marked as spam, so you have been prevented from completing your registration. If you believe this is a mistake, please contact the forum administrator.
     spammer_modal:
       hard_delete_discussions_label: Delete discussions
       hard_delete_discussions_help: This will permanently delete all discussions started by this user. When disabled, discussions will be hidden instead.

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -3,6 +3,7 @@ fof-anti-spam:
     permissions:
       spamblock_users_label: Mark user as spammer
     settings:
+      button: Settings
       default-actions:
         delete_user_label: Delete user
         delete_user_help: This will permanently delete the user. When disabled, the user will be suspended instead.
@@ -51,6 +52,19 @@ fof-anti-spam:
 
         sfs_lookup_label: Lookup registrations
         sfs_lookup_help: If enabled, we will check the StopForumSpam database when a new user registers on your forum. If the user is found (username, IP address, email) and that data point is enabled along with the SFS confidence level reaching your defined level, they will be prevented from completing their registration.
+    blocked_registrations:
+      button: Blocked Registrations
+      title: Blocked Registrations
+      no-records: No blocked registrations found.
+      help: |
+        This page shows all registrations that have been blocked by the StopForumSpam service. You can view the details of each registration, and if you wish, you can delete the record from the database.
+      attempted-at: Attempted at
+      ip: IP Address
+      email: Email Address
+      username: Username
+      login-provider: Login Provider
+      login-provider-data: Login Provider Data
+      sfs-data: StopForumSpam Data
 
   forum:
     message:

--- a/migrations/2023_11_29_000000_create_blocked_registrations_table.php
+++ b/migrations/2023_11_29_000000_create_blocked_registrations_table.php
@@ -1,0 +1,18 @@
+<?php
+
+use Flarum\Database\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+return Migration::createTable(
+    'blocked_registrations',
+    function (Blueprint $table) {
+        $table->increments('id');
+        $table->string('ip', 40)->nullable();
+        $table->string('email')->nullable();
+        $table->string('username')->nullable();
+        $table->mediumText('data')->nullable();
+        $table->string('provider')->nullable();
+        $table->mediumText('provider_data')->nullable();
+        $table->timestamp('attempted_at')->nullable();
+    }
+);

--- a/migrations/2023_11_29_000000_create_blocked_registrations_table.php
+++ b/migrations/2023_11_29_000000_create_blocked_registrations_table.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/anti-spam.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 use Flarum\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/src/Api/Controllers/DeleteBlockedRegistrationController.php
+++ b/src/Api/Controllers/DeleteBlockedRegistrationController.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/anti-spam.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\AntiSpam\Api\Controllers;
 
 use Flarum\Api\Controller\AbstractDeleteController;

--- a/src/Api/Controllers/DeleteBlockedRegistrationController.php
+++ b/src/Api/Controllers/DeleteBlockedRegistrationController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace FoF\AntiSpam\Api\Controllers;
+
+use Flarum\Api\Controller\AbstractDeleteController;
+use Flarum\Http\RequestUtil;
+use FoF\AntiSpam\Model\BlockedRegistration;
+use Psr\Http\Message\ServerRequestInterface;
+
+class DeleteBlockedRegistrationController extends AbstractDeleteController
+{
+    public function delete(ServerRequestInterface $request)
+    {
+        RequestUtil::getActor($request)->assertAdmin();
+
+        $id = $request->getQueryParams()['id'];
+
+        $registration = BlockedRegistration::findOrFail($id);
+
+        $registration->delete();
+    }
+}

--- a/src/Api/Controllers/ListBlockedRegistrationsController.php
+++ b/src/Api/Controllers/ListBlockedRegistrationsController.php
@@ -24,6 +24,11 @@ class ListBlockedRegistrationsController extends AbstractListController
     public $serializer = BlockedRegistrationSerializer::class;
 
     /**
+     * @var string
+     */
+    protected $contentRange;
+
+    /**
      * @var UrlGenerator
      */
     public $url;
@@ -43,7 +48,7 @@ class ListBlockedRegistrationsController extends AbstractListController
         $query = BlockedRegistration::query();
 
         $totalItems = $query->count();
-        $items = $query->orderBy('id')->skip($offset)->take($limit)->get();
+        $items = $query->orderBy('id', 'desc')->skip($offset)->take($limit)->get();
 
         $document->addPaginationLinks(
             $this->url->to('api')->route('fof-anti-spam.blocked-registrations.index'),
@@ -52,6 +57,9 @@ class ListBlockedRegistrationsController extends AbstractListController
             $limit,
             $totalItems - ($offset + $limit) > 0 ? null : 0
         );
+
+        $document->addLink('totalPages', ceil($totalItems / $limit));
+        $document->addLink('totalItems', $totalItems);
 
         return $items;
     }

--- a/src/Api/Controllers/ListBlockedRegistrationsController.php
+++ b/src/Api/Controllers/ListBlockedRegistrationsController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace FoF\AntiSpam\Api\Controllers;
+
+use Flarum\Api\Controller\AbstractListController;
+use Flarum\Http\RequestUtil;
+use Flarum\Http\UrlGenerator;
+use FoF\AntiSpam\Api\Serializers\BlockedRegistrationSerializer;
+use FoF\AntiSpam\Model\BlockedRegistration;
+use Psr\Http\Message\ServerRequestInterface;
+use Tobscure\JsonApi\Document;
+
+class ListBlockedRegistrationsController extends AbstractListController
+{
+    public $serializer = BlockedRegistrationSerializer::class;
+
+    /**
+     * @var UrlGenerator
+     */
+    public $url;
+
+    public function __construct(UrlGenerator $url)
+    {
+        $this->url = $url;
+    }
+
+    public function data(ServerRequestInterface $request, Document $document)
+    {
+        RequestUtil::getActor($request)->assertCan('fof-anti-spam.viewBlockedRegistrations');
+
+        $limit = $this->extractLimit($request);
+		$offset = $this->extractOffset($request);
+
+        $query = BlockedRegistration::query();
+
+        $totalItems = $query->count();
+		$items = $query->orderBy('id')->skip($offset)->take($limit)->get();
+
+        $document->addPaginationLinks(
+			$this->url->to('api')->route('fof-anti-spam.blocked-registrations.index'),
+			$request->getQueryParams(),
+			$offset,
+			$limit,
+			$totalItems - ($offset + $limit) > 0 ? null : 0
+		);
+
+        return $items;
+    }
+}

--- a/src/Api/Controllers/ListBlockedRegistrationsController.php
+++ b/src/Api/Controllers/ListBlockedRegistrationsController.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/anti-spam.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\AntiSpam\Api\Controllers;
 
 use Flarum\Api\Controller\AbstractListController;
@@ -29,20 +38,20 @@ class ListBlockedRegistrationsController extends AbstractListController
         RequestUtil::getActor($request)->assertCan('fof-anti-spam.viewBlockedRegistrations');
 
         $limit = $this->extractLimit($request);
-		$offset = $this->extractOffset($request);
+        $offset = $this->extractOffset($request);
 
         $query = BlockedRegistration::query();
 
         $totalItems = $query->count();
-		$items = $query->orderBy('id')->skip($offset)->take($limit)->get();
+        $items = $query->orderBy('id')->skip($offset)->take($limit)->get();
 
         $document->addPaginationLinks(
-			$this->url->to('api')->route('fof-anti-spam.blocked-registrations.index'),
-			$request->getQueryParams(),
-			$offset,
-			$limit,
-			$totalItems - ($offset + $limit) > 0 ? null : 0
-		);
+            $this->url->to('api')->route('fof-anti-spam.blocked-registrations.index'),
+            $request->getQueryParams(),
+            $offset,
+            $limit,
+            $totalItems - ($offset + $limit) > 0 ? null : 0
+        );
 
         return $items;
     }

--- a/src/Api/Controllers/ListBlockedRegistrationsController.php
+++ b/src/Api/Controllers/ListBlockedRegistrationsController.php
@@ -58,8 +58,8 @@ class ListBlockedRegistrationsController extends AbstractListController
             $totalItems - ($offset + $limit) > 0 ? null : 0
         );
 
-        $document->addLink('totalPages', ceil($totalItems / $limit));
-        $document->addLink('totalItems', $totalItems);
+        $document->addLink('totalPages', (string) ceil($totalItems / $limit));
+        $document->addLink('totalItems', (string) $totalItems);
 
         return $items;
     }

--- a/src/Api/Controllers/MarkAsSpammerController.php
+++ b/src/Api/Controllers/MarkAsSpammerController.php
@@ -17,7 +17,7 @@ use Flarum\User\User;
 use FoF\AntiSpam\Command\MarkUserAsSpammer;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Arr;
-use Laminas\Diactoros\Response\RedirectResponse;
+use Laminas\Diactoros\Response\EmptyResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -63,6 +63,6 @@ class MarkAsSpammerController implements RequestHandlerInterface
 
         $this->bus->dispatch(new MarkUserAsSpammer($user, $options, $actor));
 
-        return new RedirectResponse($this->url->to('forum')->base());
+        return new EmptyResponse();
     }
 }

--- a/src/Api/Serializers/BlockedRegistrationSerializer.php
+++ b/src/Api/Serializers/BlockedRegistrationSerializer.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace FoF\AntiSpam\Api\Serializers;
+
+use Flarum\Api\Serializer\AbstractSerializer;
+use FoF\AntiSpam\Model\BlockedRegistration;
+
+class BlockedRegistrationSerializer extends AbstractSerializer
+{
+    public $type = 'blocked-registrations';
+    
+    /**
+     * @param BlockedRegistration $blocked
+     * @return array
+     */
+    public function getDefaultAttributes($blocked): array
+    {
+        return [
+            'ip' => $blocked->ip,
+            'email' => $blocked->email,
+            'username' => $blocked->username,
+            'data' => $blocked->data,
+            'provider' => $blocked->provider,
+            'providerData' => $blocked->provider_data,
+            'attemptedAt' => $this->formatDate($blocked->attempted_at),
+        ];
+    }
+}

--- a/src/Api/Serializers/BlockedRegistrationSerializer.php
+++ b/src/Api/Serializers/BlockedRegistrationSerializer.php
@@ -28,7 +28,7 @@ class BlockedRegistrationSerializer extends AbstractSerializer
             'ip' => $blocked->ip,
             'email' => $blocked->email,
             'username' => $blocked->username,
-            'data' => $blocked->data,
+            'sfsData' => $blocked->data,
             'provider' => $blocked->provider,
             'providerData' => $blocked->provider_data,
             'attemptedAt' => $this->formatDate($blocked->attempted_at),

--- a/src/Api/Serializers/BlockedRegistrationSerializer.php
+++ b/src/Api/Serializers/BlockedRegistrationSerializer.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/anti-spam.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\AntiSpam\Api\Serializers;
 
 use Flarum\Api\Serializer\AbstractSerializer;
@@ -8,7 +17,7 @@ use FoF\AntiSpam\Model\BlockedRegistration;
 class BlockedRegistrationSerializer extends AbstractSerializer
 {
     public $type = 'blocked-registrations';
-    
+
     /**
      * @param BlockedRegistration $blocked
      * @return array

--- a/src/Api/SfsClient.php
+++ b/src/Api/SfsClient.php
@@ -41,7 +41,7 @@ class SfsClient
 
         $this->client = new Client([
             'base_uri' => $this->endpoint(),
-            'verify'   => false,
+            'verify'   => false
         ]);
     }
 

--- a/src/Api/SfsClient.php
+++ b/src/Api/SfsClient.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace FoF\AntiSpam\Api;
+
+use Flarum\Settings\SettingsRepositoryInterface;
+use GuzzleHttp\Client;
+use Psr\Http\Message\ResponseInterface;
+
+class SfsClient
+{
+    public const KEY = 'fof-anti-spam.api_key';
+
+    protected $endpoints = [
+        'closest' => 'https://api.stopforumspam.org/',
+        'europe'  => 'https://europe.stopforumspam.org/',
+        'us'      => 'https://us.stopforumspam.org/',
+    ];
+
+    /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    public function __construct(SettingsRepositoryInterface $settings)
+    {
+        $this->settings = $settings;
+
+        $this->client = new Client([
+            'base_uri' => $this->endpoint(),
+            'verify'   => false,
+        ]);
+    }
+
+    private function endpoint(): string
+    {
+        return $this->endpoints[$this->settings->get('fof-anti-spam.regionalEndpoint')] ?? $this->endpoints['closest'];
+    }
+
+    public function check(?string $ip, ?string $email, ?string $username): SfsResponse
+    {
+        $data = $this->buildDataArray($ip, $email, $username);
+        $response = $this->call('api', $data);
+        return $this->parseResponse($response);
+    }
+
+    private function buildDataArray(?string $ip, ?string $email, ?string $username): array
+    {
+        $data = [
+            'ip' => $ip,
+            'username' => $username,
+            'json' => true
+        ];
+
+        if ((bool) $this->settings->get('fof-anti-spam.emailhash')) {
+            $data['emailhash'] = md5($email);
+        }
+
+        $data['email'] = $email;
+
+        return $data;
+    }
+
+    private function parseResponse(ResponseInterface $response): SfsResponse
+    {
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        return new SfsResponse($json);
+    }
+
+    public function report(array $data): ResponseInterface
+    {
+        $data['api_key'] = $this->settings->get(self::KEY);
+
+        return $this->call('https://www.stopforumspam.com/add', $data);
+    }
+
+    private function call(string $url, array $data): ResponseInterface
+    {
+        return $this->client->post($url, [
+            'form_params' => $data,
+        ]);
+    }
+}

--- a/src/Api/SfsClient.php
+++ b/src/Api/SfsClient.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/anti-spam.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\AntiSpam\Api;
 
 use Flarum\Settings\SettingsRepositoryInterface;
@@ -45,6 +54,7 @@ class SfsClient
     {
         $data = $this->buildDataArray($ip, $email, $username);
         $response = $this->call('api', $data);
+
         return $this->parseResponse($response);
     }
 

--- a/src/Api/SfsClient.php
+++ b/src/Api/SfsClient.php
@@ -22,7 +22,7 @@ class SfsClient
     protected $endpoints = [
         'closest' => 'https://api.stopforumspam.org/',
         'europe'  => 'https://europe.stopforumspam.org/',
-        'us'      => 'https://us.stopforumspam.org/',
+        'us'      => 'https://us.stopforumspam.org/'
     ];
 
     /**

--- a/src/Api/SfsResponse.php
+++ b/src/Api/SfsResponse.php
@@ -46,12 +46,35 @@ class SfsResponse
 
 class BasicFieldData
 {
-    public string $value;
-    public bool $appears;
-    public ?int $frequency = null;
-    public ?string $lastseen = null;
-    public ?float $confidence = null;
-    public bool $blacklisted;
+    /**
+     * @var string
+     */
+    public $value;
+
+    /**
+     * @var boolean
+     */
+    public $appears;
+
+    /**
+     * @var integer|null
+     */
+    public $frequency = null;
+
+    /**
+     * @var string|null
+     */
+    public $lastseen = null;
+
+    /**
+     * @var float|null
+     */
+    public $confidence = null;
+
+    /**
+     * @var boolean
+     */
+    public $blacklisted;
 
     public function __construct(array $fieldData)
     {
@@ -66,8 +89,15 @@ class BasicFieldData
 
 class IpFieldData extends BasicFieldData
 {
-    public ?int $asn = null;
-    public ?string $country = null;
+    /**
+     * @var integer|null
+     */
+    public $asn = null;
+
+    /**
+     * @var string|null
+     */
+    public $country = null;
 
     public function __construct(array $fieldData)
     {

--- a/src/Api/SfsResponse.php
+++ b/src/Api/SfsResponse.php
@@ -72,7 +72,7 @@ class BasicFieldData
     public $confidence = null;
 
     /**
-     * @var bool
+     * @var bool|null
      */
     public $blacklisted;
 

--- a/src/Api/SfsResponse.php
+++ b/src/Api/SfsResponse.php
@@ -15,14 +15,17 @@ use Illuminate\Support\Arr;
 
 class SfsResponse
 {
-    public bool $success;
+    /**
+     * @var bool
+     */
+    public $success;
     public ?IpFieldData $ip;
     public ?BasicFieldData $username;
     public ?BasicFieldData $email;
 
     public function __construct(array $data)
     {
-        $this->success = Arr::get($data, 'success', false);
+        $this->success = (bool) Arr::get($data, 'success', false);
         $this->ip = isset($data['ip']) ? new IpFieldData($data['ip']) : null;
         $this->username = isset($data['username']) ? new BasicFieldData($data['username']) : null;
         $this->email = isset($data['email']) ? new BasicFieldData($data['email']) : (isset($data['emailhash']) ? new BasicFieldData($data['emailhash']) : null);

--- a/src/Api/SfsResponse.php
+++ b/src/Api/SfsResponse.php
@@ -19,9 +19,21 @@ class SfsResponse
      * @var bool
      */
     public $success;
-    public ?IpFieldData $ip;
-    public ?BasicFieldData $username;
-    public ?BasicFieldData $email;
+
+    /**
+     * @var IpFieldData|null
+     */
+    public $ip;
+
+    /**
+     * @var BasicFieldData|null
+     */
+    public $username;
+
+    /**
+     * @var BasicFieldData|null
+     */
+    public $email;
 
     public function __construct(array $data)
     {

--- a/src/Api/SfsResponse.php
+++ b/src/Api/SfsResponse.php
@@ -52,12 +52,12 @@ class BasicFieldData
     public $value;
 
     /**
-     * @var boolean
+     * @var bool
      */
     public $appears;
 
     /**
-     * @var integer|null
+     * @var int|null
      */
     public $frequency = null;
 
@@ -72,7 +72,7 @@ class BasicFieldData
     public $confidence = null;
 
     /**
-     * @var boolean
+     * @var bool
      */
     public $blacklisted;
 
@@ -90,7 +90,7 @@ class BasicFieldData
 class IpFieldData extends BasicFieldData
 {
     /**
-     * @var integer|null
+     * @var int|null
      */
     public $asn = null;
 

--- a/src/Api/SfsResponse.php
+++ b/src/Api/SfsResponse.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace FoF\AntiSpam\Api;
+
+use Illuminate\Support\Arr;
+
+class SfsResponse
+{
+    public bool $success;
+    public ?IpFieldData $ip;
+    public ?BasicFieldData $username;
+    public ?BasicFieldData $email;
+
+    public function __construct(array $data)
+    {
+        $this->success = (bool) Arr::get($data, 'success', false);
+        $this->ip = isset($data['ip']) ? new IpFieldData($data['ip']) : null;
+        $this->username = isset($data['username']) ? new BasicFieldData($data['username']) : null;
+        $this->email = isset($data['email']) ? new BasicFieldData($data['email']) : (isset($data['emailhash']) ? new BasicFieldData($data['emailhash']) : null);
+    }
+}
+
+class BasicFieldData
+{
+    public string $value;
+    public bool $appears;
+    public ?int $frequency = null;
+    public ?string $lastseen = null;
+    public ?float $confidence = null;
+    public bool $blacklisted;
+
+
+    public function __construct(array $fieldData)
+    {
+        $this->value = Arr::get($fieldData, 'value');
+        $this->appears = Arr::get($fieldData, 'appears')  !== null ? (bool) Arr::get($fieldData, 'appears') : false;
+        $this->frequency = Arr::get($fieldData, 'frequency') !== null ? (int) Arr::get($fieldData, 'frequency') : null;
+        $this->lastseen = Arr::get($fieldData, 'lastseen');
+        $this->confidence = Arr::get($fieldData, 'confidence') !== null ? (float) Arr::get($fieldData, 'confidence') : null;
+        $this->blacklisted = Arr::get($fieldData, 'blacklisted') !== null ? (bool) Arr::get($fieldData, 'blacklisted') : false;
+    }
+}
+
+class IpFieldData extends BasicFieldData
+{
+    public ?int $asn = null;
+    public ?string $country = null;
+
+    public function __construct(array $fieldData)
+    {
+        parent::__construct($fieldData);
+        $this->asn = Arr::get($fieldData, 'asn') !== null ? (int) Arr::get($fieldData, 'asn') : null;
+        $this->country = Arr::get($fieldData, 'country');
+    }
+}

--- a/src/Api/SfsResponse.php
+++ b/src/Api/SfsResponse.php
@@ -22,7 +22,7 @@ class SfsResponse
 
     public function __construct(array $data)
     {
-        $this->success = (bool) Arr::get($data, 'success', false);
+        $this->success = Arr::get($data, 'success', false);
         $this->ip = isset($data['ip']) ? new IpFieldData($data['ip']) : null;
         $this->username = isset($data['username']) ? new BasicFieldData($data['username']) : null;
         $this->email = isset($data['email']) ? new BasicFieldData($data['email']) : (isset($data['emailhash']) ? new BasicFieldData($data['emailhash']) : null);

--- a/src/Api/SfsResponse.php
+++ b/src/Api/SfsResponse.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/anti-spam.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\AntiSpam\Api;
 
 use Illuminate\Support\Arr;
@@ -29,11 +38,10 @@ class BasicFieldData
     public ?float $confidence = null;
     public bool $blacklisted;
 
-
     public function __construct(array $fieldData)
     {
         $this->value = Arr::get($fieldData, 'value');
-        $this->appears = Arr::get($fieldData, 'appears')  !== null ? (bool) Arr::get($fieldData, 'appears') : false;
+        $this->appears = Arr::get($fieldData, 'appears') !== null ? (bool) Arr::get($fieldData, 'appears') : false;
         $this->frequency = Arr::get($fieldData, 'frequency') !== null ? (int) Arr::get($fieldData, 'frequency') : null;
         $this->lastseen = Arr::get($fieldData, 'lastseen');
         $this->confidence = Arr::get($fieldData, 'confidence') !== null ? (float) Arr::get($fieldData, 'confidence') : null;

--- a/src/Command/MarkUserAsSpammerHandler.php
+++ b/src/Command/MarkUserAsSpammerHandler.php
@@ -143,11 +143,6 @@ class MarkUserAsSpammerHandler
                     'attributes' => ['suspendedUntil' => Carbon::now()->addYears(20)],
                 ])
             );
-        } else {
-            $this->log->info('User was marked as spam, but no action was taken.', [
-                'user' => $user->id,
-                'actor' => $actor->id,
-            ]);
         }
 
         $user->refreshDiscussionCount();

--- a/src/Event/RegistrationBlocked.php
+++ b/src/Event/RegistrationBlocked.php
@@ -11,6 +11,9 @@
 
 namespace FoF\AntiSpam\Event;
 
+/**
+ * @deprecated Use `\FoF\AntiSpam\Event\RegistrationWasBlocked` instead. Will be removed in Flarum 2.0
+ */
 class RegistrationBlocked
 {
     public $username;

--- a/src/Event/RegistrationWasBlocked.php
+++ b/src/Event/RegistrationWasBlocked.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/anti-spam.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\AntiSpam\Event;
 
 use FoF\AntiSpam\Model\BlockedRegistration;
@@ -7,7 +16,7 @@ use FoF\AntiSpam\Model\BlockedRegistration;
 class RegistrationWasBlocked
 {
     public $blocked;
-    
+
     public function __construct(BlockedRegistration $blocked)
     {
         $this->blocked = $blocked;

--- a/src/Event/RegistrationWasBlocked.php
+++ b/src/Event/RegistrationWasBlocked.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace FoF\AntiSpam\Event;
+
+use FoF\AntiSpam\Model\BlockedRegistration;
+
+class RegistrationWasBlocked
+{
+    public $blocked;
+    
+    public function __construct(BlockedRegistration $blocked)
+    {
+        $this->blocked = $blocked;
+    }
+}

--- a/src/Job/ReportSpammerJob.php
+++ b/src/Job/ReportSpammerJob.php
@@ -12,6 +12,7 @@
 namespace FoF\AntiSpam\Job;
 
 use Flarum\Queue\AbstractJob;
+use FoF\AntiSpam\Api\SfsClient;
 use FoF\AntiSpam\StopForumSpam;
 use Psr\Log\LoggerInterface;
 
@@ -28,16 +29,14 @@ class ReportSpammerJob extends AbstractJob
         $this->ipAddress = $ipAddress;
     }
 
-    public function handle(StopForumSpam $sfs, LoggerInterface $log)
+    public function handle(StopForumSpam $sfs, SfsClient $client, LoggerInterface $log)
     {
         if (! $sfs->isEnabled()) {
-            $log->info('[FoF Anti Spam] Tried to report spammer to StopForumSpam, but not API key was configured.');
-
             return;
         }
 
         try {
-            $sfs->report([
+            $client->report([
                 'ip_addr'  => $this->ipAddress,
                 'username' => $this->username,
                 'email'    => $this->email,

--- a/src/Listener/ProviderRegistration.php
+++ b/src/Listener/ProviderRegistration.php
@@ -37,7 +37,7 @@ class ProviderRegistration
 
         if ($check) {
             throw new ValidationException([
-                'username' => resolve('translator')->trans('fof-anti-spam.forum.message.spam'),
+                'username' => resolve('translator')->trans('fof-anti-spam.forum.message.stopforumspam.blocked'),
             ]);
         }
     }

--- a/src/Listener/ProviderRegistration.php
+++ b/src/Listener/ProviderRegistration.php
@@ -27,11 +27,13 @@ class ProviderRegistration
 
     public function handle(RegisteringFromProvider $event)
     {
-        $check = $this->sfs->shouldPreventLogin([
-            'ip'       => $this->getIpAddress(),
-            'email'    => $event->user->email,
-            'username' => $event->user->username,
-        ], $event->provider, $event->payload);
+        $check = $this->sfs->shouldPreventLogin(
+            $this->getIpAddress(),
+            $event->user->email,
+            $event->user->username,
+            $event->provider,
+            $event->payload
+        );
 
         if ($check) {
             throw new ValidationException([

--- a/src/Middleware/CheckLoginMiddleware.php
+++ b/src/Middleware/CheckLoginMiddleware.php
@@ -68,7 +68,7 @@ class CheckLoginMiddleware implements MiddlewareInterface
                     ->format(
                         resolve(Registry::class)
                             ->handle(new ValidationException([
-                                'username' => resolve('translator')->trans('fof-anti-spam.forum.message.spam'),
+                                'username' => resolve('translator')->trans('fof-anti-spam.forum.message.stopforumspam.blocked'),
                             ])),
                         $request
                     );

--- a/src/Middleware/CheckLoginMiddleware.php
+++ b/src/Middleware/CheckLoginMiddleware.php
@@ -48,18 +48,20 @@ class CheckLoginMiddleware implements MiddlewareInterface
         if ($request->getUri()->getPath() === $registerPath) {
             $data = $request->getParsedBody();
 
-            try {
-                $shouldPrevent = $this->sfs->shouldPreventLogin([
-                    'ip'       => $this->getIpAddress($request),
-                    'email'    => $data['email'],
-                    'username' => $data['username'],
-                ]);
-            } catch (\Throwable $e) {
-                return (new JsonApiFormatter())->format(
-                    resolve(Registry::class)->handle($e),
-                    $request
+            //try {
+                $shouldPrevent = $this->sfs->shouldPreventLogin(
+                    $this->getIpAddress($request),
+                    $data['email'],
+                    $data['username'],
+                    'forum',
+                    $data
                 );
-            }
+            // } catch (\Throwable $e) {
+            //     return (new JsonApiFormatter())->format(
+            //         resolve(Registry::class)->handle($e),
+            //         $request
+            //     );
+            // }
 
             if ($shouldPrevent) {
                 return (new JsonApiFormatter())

--- a/src/Middleware/CheckLoginMiddleware.php
+++ b/src/Middleware/CheckLoginMiddleware.php
@@ -49,13 +49,13 @@ class CheckLoginMiddleware implements MiddlewareInterface
             $data = $request->getParsedBody();
 
             //try {
-                $shouldPrevent = $this->sfs->shouldPreventLogin(
-                    $this->getIpAddress($request),
-                    $data['email'],
-                    $data['username'],
-                    'forum',
-                    $data
-                );
+            $shouldPrevent = $this->sfs->shouldPreventLogin(
+                $this->getIpAddress($request),
+                $data['email'],
+                $data['username'],
+                'forum',
+                $data
+            );
             // } catch (\Throwable $e) {
             //     return (new JsonApiFormatter())->format(
             //         resolve(Registry::class)->handle($e),

--- a/src/Middleware/CheckLoginMiddleware.php
+++ b/src/Middleware/CheckLoginMiddleware.php
@@ -68,7 +68,7 @@ class CheckLoginMiddleware implements MiddlewareInterface
                     ->format(
                         resolve(Registry::class)
                             ->handle(new ValidationException([
-                                'username' => resolve('translator')->trans('fof-stopforumspam.forum.message.spam'),
+                                'username' => resolve('translator')->trans('fof-anti-spam.forum.message.spam'),
                             ])),
                         $request
                     );

--- a/src/Model/BlockedRegistration.php
+++ b/src/Model/BlockedRegistration.php
@@ -21,7 +21,7 @@ use Flarum\Database\AbstractModel;
  * @property string $username
  * @property string $data
  * @property string|null $provider
- * @property array|null $provider_data
+ * @property string|false $provider_data
  * @property Carbon $attempted_at
  */
 class BlockedRegistration extends AbstractModel

--- a/src/Model/BlockedRegistration.php
+++ b/src/Model/BlockedRegistration.php
@@ -22,7 +22,7 @@ use Flarum\Database\AbstractModel;
  * @property string $data
  * @property string|null $provider
  * @property array|null $provider_data
- * @property DateTime $attempted_at
+ * @property Carbon $attempted_at
  */
 class BlockedRegistration extends AbstractModel
 {

--- a/src/Model/BlockedRegistration.php
+++ b/src/Model/BlockedRegistration.php
@@ -41,7 +41,7 @@ class BlockedRegistration extends AbstractModel
         $blocked->username = $username;
         $blocked->data = $data;
         $blocked->provider = $provider;
-        $blocked->provider_data = $providerData;
+        $blocked->provider_data = json_encode($providerData);
         $blocked->attempted_at = Carbon::now();
 
         $blocked->save();

--- a/src/Model/BlockedRegistration.php
+++ b/src/Model/BlockedRegistration.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/anti-spam.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\AntiSpam\Model;
 
 use Carbon\Carbon;

--- a/src/Model/BlockedRegistration.php
+++ b/src/Model/BlockedRegistration.php
@@ -19,10 +19,10 @@ use Flarum\Database\AbstractModel;
  * @property string $ip
  * @property string $email
  * @property string $username
- * @property array $data
+ * @property string $data
  * @property string|null $provider
  * @property array|null $provider_data
- * @property Carbon $attempted_at
+ * @property DateTime $attempted_at
  */
 class BlockedRegistration extends AbstractModel
 {
@@ -30,10 +30,9 @@ class BlockedRegistration extends AbstractModel
 
     public $casts = [
         'attempted_at' => 'datetime',
-        'data' => 'array'
     ];
 
-    public static function create(string $ip, string $email, string $username, array $data, ?string $provider = null, ?array $providerData = null): self
+    public static function create(string $ip, string $email, string $username, string $data, ?string $provider = null, ?array $providerData = null): self
     {
         $blocked = new static();
 

--- a/src/Model/BlockedRegistration.php
+++ b/src/Model/BlockedRegistration.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace FoF\AntiSpam\Model;
+
+use Carbon\Carbon;
+use Flarum\Database\AbstractModel;
+
+/**
+ * @property int    $id
+ * @property string $ip
+ * @property string $email
+ * @property string $username
+ * @property array $data
+ * @property string|null $provider
+ * @property string|null $provider_data
+ * @property Carbon $attempted_at
+ */
+class BlockedRegistration extends AbstractModel
+{
+    public $table = 'blocked_registrations';
+
+    public $casts = [
+        'attempted_at' => 'datetime',
+        'data' => 'array'
+    ];
+
+    public static function create(string $ip, string $email, string $username, array $data, ?string $provider = null, ?array $providerData = null): self
+    {
+        $blocked = new static();
+
+        $blocked->ip = $ip;
+        $blocked->email = $email;
+        $blocked->username = $username;
+        $blocked->data = $data;
+        $blocked->provider = $provider;
+        $blocked->provider_data = $providerData;
+        $blocked->attempted_at = Carbon::now();
+
+        $blocked->save();
+
+        return $blocked;
+    }
+}

--- a/src/Model/BlockedRegistration.php
+++ b/src/Model/BlockedRegistration.php
@@ -12,7 +12,7 @@ use Flarum\Database\AbstractModel;
  * @property string $username
  * @property array $data
  * @property string|null $provider
- * @property string|null $provider_data
+ * @property array|null $provider_data
  * @property Carbon $attempted_at
  */
 class BlockedRegistration extends AbstractModel

--- a/src/Providers/SfsProvider.php
+++ b/src/Providers/SfsProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/anti-spam.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\AntiSpam\Providers;
 
 use Flarum\Foundation\AbstractServiceProvider;

--- a/src/Providers/SfsProvider.php
+++ b/src/Providers/SfsProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace FoF\AntiSpam\Providers;
+
+use Flarum\Foundation\AbstractServiceProvider;
+use FoF\AntiSpam\Api\SfsClient;
+use Illuminate\Contracts\Container\Container;
+
+class SfsProvider extends AbstractServiceProvider
+{
+    public function register()
+    {
+        $this->container->singleton(SfsClient::class, function (Container $container) {
+            return new SfsClient($container->make('flarum.settings'));
+        });
+    }
+}

--- a/src/StopForumSpam.php
+++ b/src/StopForumSpam.php
@@ -62,7 +62,7 @@ class StopForumSpam
     {
         $key = $this->settings->get(self::KEY);
 
-        return $key !== null && !empty($key);
+        return $key !== null && ! empty($key);
     }
 
     public function report(array $data): ResponseInterface
@@ -91,7 +91,7 @@ class StopForumSpam
     public function shouldPreventLogin(array $data, ?string $provider = null, ?array $providerData = null): bool
     {
         // If we don't have sfs lookup enabled, we return false early.
-        if (!(bool) $this->settings->get('fof-anti-spam.sfs-lookup')) {
+        if (! (bool) $this->settings->get('fof-anti-spam.sfs-lookup')) {
             return false;
         }
 

--- a/src/StopForumSpam.php
+++ b/src/StopForumSpam.php
@@ -44,11 +44,11 @@ class StopForumSpam
     {
         $key = $this->settings->get(SfsClient::KEY);
 
-        return $key !== null && !empty($key);
+        return $key !== null && ! empty($key);
     }
 
     /**
-     * Validates against the StopForumSpam API. Returns a simple boolean indicating if based on the current 
+     * Validates against the StopForumSpam API. Returns a simple boolean indicating if based on the current
      * extension settings this registration should be prevented or not.
      *
      * @return bool
@@ -56,7 +56,7 @@ class StopForumSpam
     public function shouldPreventLogin(?string $ip, ?string $email, ?string $username, ?string $provider = null, ?array $providerData = null): bool
     {
         // If we don't have sfs lookup enabled, we return false early.
-        if (!(bool) $this->settings->get('fof-anti-spam.sfs-lookup')) {
+        if (! (bool) $this->settings->get('fof-anti-spam.sfs-lookup')) {
             return false;
         }
 
@@ -70,7 +70,7 @@ class StopForumSpam
             $blacklisted = false;
 
             foreach (['ip' => $sfsResponse->ip, 'email' => $sfsResponse->email, 'username' => $sfsResponse->username] as $key => $value) {
-                if ($value === null || !(bool) $this->settings->get("fof-anti-spam.$key")) {
+                if ($value === null || ! (bool) $this->settings->get("fof-anti-spam.$key")) {
                     continue;
                 }
 
@@ -79,11 +79,12 @@ class StopForumSpam
                 }
 
                 $frequency += $value->frequency ?? 0;
-                $confidence += $value->confidence ?? 0.0;               
+                $confidence += $value->confidence ?? 0.0;
             }
 
             if ($confidence >= $requiredConfidence || $frequency >= $requiredFrequency || $blacklisted) {
                 $this->buildAndDispatchEvents(['ip' => $ip, 'email' => $email, 'username' => $username], json_encode($sfsResponse), $provider, $providerData);
+
                 return true;
             }
         }
@@ -91,13 +92,12 @@ class StopForumSpam
         return false;
     }
 
-
     private function buildAndDispatchEvents(array $data, string $sfsData, string $provider = null, array $providerData = null): void
     {
         $ip = Arr::get($data, 'ip') ?? 'unknown';
         $email = Arr::get($data, 'email') ?? 'unknown';
         $username = Arr::get($data, 'username') ?? 'unknown';
-        
+
         // If there's a password in the provider data, we remove it from the data we send to the event.
         Arr::pull($providerData, 'password');
 

--- a/src/StopForumSpam.php
+++ b/src/StopForumSpam.php
@@ -12,124 +12,78 @@
 namespace FoF\AntiSpam;
 
 use Flarum\Settings\SettingsRepositoryInterface;
-use GuzzleHttp\Client;
+use FoF\AntiSpam\Api\SfsClient;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
-use Psr\Http\Message\ResponseInterface;
 
 class StopForumSpam
 {
-    private const KEY = 'fof-anti-spam.api_key';
-
-    protected $endpoints = [
-        'closest' => 'https://api.stopforumspam.org/',
-        'europe'  => 'https://europe.stopforumspam.org/',
-        'us'      => 'https://us.stopforumspam.org/',
-    ];
-
     /**
      * @var SettingsRepositoryInterface
      */
-    private $settings;
-
-    /**
-     * @var Client
-     */
-    private $client;
+    protected $settings;
 
     /**
      * @var Dispatcher
      */
-    private $bus;
+    protected $bus;
 
-    public function __construct(SettingsRepositoryInterface $settings, Dispatcher $bus)
+    /**
+     * @var SfsClient
+     */
+    protected $client;
+
+    public function __construct(SettingsRepositoryInterface $settings, Dispatcher $bus, SfsClient $client)
     {
         $this->settings = $settings;
         $this->bus = $bus;
-
-        $this->client = new Client([
-            'base_uri' => $this->endpoint(),
-            'verify'   => false,
-        ]);
-    }
-
-    private function endpoint(): string
-    {
-        return $this->endpoints[$this->settings->get('fof-anti-spam.regionalEndpoint')];
+        $this->client = $client;
     }
 
     public function isEnabled(): bool
     {
-        $key = $this->settings->get(self::KEY);
+        $key = $this->settings->get(SfsClient::KEY);
 
-        return $key !== null && ! empty($key);
-    }
-
-    public function report(array $data): ResponseInterface
-    {
-        $data['api_key'] = $this->settings->get(self::KEY);
-
-        return $this->call('https://www.stopforumspam.com/add', $data);
-    }
-
-    private function call(string $url, array $data): ResponseInterface
-    {
-        return $this->client->post($url, [
-            'form_params' => $data,
-        ]);
+        return $key !== null && !empty($key);
     }
 
     /**
-     * Consumes an array containing `ip`, `email` and `username` and validates against the StopForumSpam API.
-     * Returns a simple boolean indicating if based on the current extension settings this registration
-     * should be prevented or not.
-     *
-     * @param array $data
+     * Validates against the StopForumSpam API. Returns a simple boolean indicating if based on the current 
+     * extension settings this registration should be prevented or not.
      *
      * @return bool
      */
-    public function shouldPreventLogin(array $data, ?string $provider = null, ?array $providerData = null): bool
+    public function shouldPreventLogin(?string $ip, ?string $email, ?string $username, ?string $provider = null, ?array $providerData = null): bool
     {
         // If we don't have sfs lookup enabled, we return false early.
-        if (! (bool) $this->settings->get('fof-anti-spam.sfs-lookup')) {
+        if (!(bool) $this->settings->get('fof-anti-spam.sfs-lookup')) {
             return false;
         }
 
-        $data['json'] = 1;
+        $sfsResponse = $this->client->check($ip, $email, $username);
 
-        $hashEmail = (bool) $this->settings->get('fof-anti-spam.emailhash');
-
-        if ($hashEmail) {
-            $data['emailhash'] = md5($data['email']);
-            Arr::pull($data, 'email');
-        }
-
-        $response = $this->call('api', $data);
-        $body = json_decode($response->getBody());
-
-        if ($body->success === 1) {
-            unset($body->success);
-
+        if ($sfsResponse->success) {
             $requiredFrequency = (int) $this->settings->get('fof-anti-spam.frequency');
             $requiredConfidence = (float) $this->settings->get('fof-anti-spam.confidence');
             $frequency = 0;
             $confidence = 0.0;
+            $blacklisted = false;
 
-            foreach ($body as $key => $value) {
-                if ((int) $this->settings->get("fof-anti-spam.$key")) {
-                    if (isset($value->frequency)) {
-                        $frequency += $value->frequency;
-                    }
-
-                    if (isset($value->confidence)) {
-                        $confidence += $value->confidence;
-                    }
+            foreach (['ip' => $sfsResponse->ip, 'email' => $sfsResponse->email, 'username' => $sfsResponse->username] as $key => $value) {
+                if ($value === null || !(bool) $this->settings->get("fof-anti-spam.$key")) {
+                    continue;
                 }
+
+                if (isset($value->blacklisted) && $value->blacklisted) {
+                    $blacklisted = true;
+                }
+
+                $frequency += $value->frequency ?? 0;
+                $confidence += $value->confidence ?? 0.0;               
             }
 
-            if ($confidence >= $requiredConfidence || $frequency >= $requiredFrequency) {
-                $this->buildAndDispatchEvents($data, $provider, $providerData);
-
+            if ($confidence >= $requiredConfidence || $frequency >= $requiredFrequency || $blacklisted) {
+                $this->buildAndDispatchEvents(['ip' => $ip, 'email' => $email, 'username' => $username], json_encode($sfsResponse), $provider, $providerData);
                 return true;
             }
         }
@@ -137,18 +91,22 @@ class StopForumSpam
         return false;
     }
 
-    private function buildAndDispatchEvents(array $data, string $provider = null, array $providerData = null): void
+
+    private function buildAndDispatchEvents(array $data, string $sfsData, string $provider = null, array $providerData = null): void
     {
-        $ip = Arr::pull($data, 'ip', 'unknown');
-        $email = Arr::pull($data, 'email', 'unknown');
-        $username = Arr::pull($data, 'username', 'unknown');
+        $ip = Arr::get($data, 'ip') ?? 'unknown';
+        $email = Arr::get($data, 'email') ?? 'unknown';
+        $username = Arr::get($data, 'username') ?? 'unknown';
+        
+        // If there's a password in the provider data, we remove it from the data we send to the event.
+        Arr::pull($providerData, 'password');
 
         $this->bus->dispatch(new Event\RegistrationWasBlocked(
             Model\BlockedRegistration::create(
                 $ip,
                 $email,
                 $username,
-                $data,
+                $sfsData,
                 $provider,
                 $providerData
             )

--- a/tests/integration/SpamblockTest.php
+++ b/tests/integration/SpamblockTest.php
@@ -115,7 +115,7 @@ class SpamblockTest extends TestCase
             ])
         );
 
-        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals(204, $response->getStatusCode());
 
         $response = $this->send(
             $this->request('GET', 'api/discussions/2', [
@@ -144,7 +144,7 @@ class SpamblockTest extends TestCase
             ])
         );
 
-        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals(204, $response->getStatusCode());
 
         $user = User::find(5);
 

--- a/tests/integration/SpamblockTest.php
+++ b/tests/integration/SpamblockTest.php
@@ -86,7 +86,7 @@ class SpamblockTest extends TestCase
             ])
         );
 
-        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals(204, $response->getStatusCode());
 
         $response = $this->send(
             $this->request('GET', 'api/discussions/2', [

--- a/tests/integration/api/BlockedRegistrationsTest.php
+++ b/tests/integration/api/BlockedRegistrationsTest.php
@@ -13,6 +13,7 @@ namespace FoF\AntiSpam\Tests\integration\api;
 
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use FoF\AntiSpam\Model\BlockedRegistration;
 
 class BlockedRegistrationsTest extends TestCase
 {
@@ -32,6 +33,9 @@ class BlockedRegistrationsTest extends TestCase
             ],
             'group_permission' => [
                 ['permission' => 'fof-anti-spam.viewBlockedRegistrations', 'group_id' => 4]
+            ],
+            'blocked_registrations' => [
+                ['id' => 1, 'ip' => '127.0.0.1', 'email' => 'spammer@machine.local', 'username' => 'spammer', 'attempted_at' => '2020-01-01 00:00:00']
             ]
         ]);
     }
@@ -79,5 +83,57 @@ class BlockedRegistrationsTest extends TestCase
 
         // assert response has data
         $this->assertObjectHasProperty('data', $body);
+        $this->assertCount(1, $body->data);
+
+        $data = $body->data[0];
+
+        $this->assertEquals(1, $data->id);
+        $this->assertEquals('127.0.0.1', $data->attributes->ip);
+        $this->assertEquals('spammer@machine.local', $data->attributes->email);
+    }
+
+
+    /**
+     * @test
+     */
+    public function user_without_permission_cannot_delete_blocked_registrations()
+    {
+        $response = $this->send(
+            $this->request(
+                'DELETE',
+                '/api/blocked-registrations/1',
+                [
+                    'authenticatedAs' => 3,
+                ]
+            )
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+
+        $blocked = BlockedRegistration::all();
+
+        $this->assertCount(1, $blocked);
+    }
+
+    /**
+     * @test
+     */
+    public function user_with_permission_can_delete_blocked_registrations()
+    {
+        $response = $this->send(
+            $this->request(
+                'DELETE',
+                '/api/blocked-registrations/1',
+                [
+                    'authenticatedAs' => 1,
+                ]
+            )
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+
+        $blocked = BlockedRegistration::all();
+
+        $this->assertCount(0, $blocked);
     }
 }

--- a/tests/integration/api/BlockedRegistrationsTest.php
+++ b/tests/integration/api/BlockedRegistrationsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace FoF\AntiSpam\Tests\integration\api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class BlockedRegistrationsTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    public function setUp(): void
+    {
+        $this->extension('fof-anti-spam');
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'moderator', 'email' => 'moderator@machine.local', 'is_email_confirmed' => true]
+            ],
+            'group_user' => [
+                ['user_id' => 3, 'group_id' => 4]
+            ],
+            'group_permission' => [
+                ['permission' => 'fof-anti-spam.viewBlockedRegistrations', 'group_id' => 4]
+            ]
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function user_without_permission_cannot_list_blocked_registrations()
+    {
+        $response = $this->send(
+            $this->request(
+                'GET', 
+                '/api/blocked-registrations',
+                [
+                    'authenticatedAs' => 2,
+                ]
+            )
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function user_with_permission_can_list_blocked_registrations()
+    {
+        $response = $this->send(
+            $this->request(
+                'GET', 
+                '/api/blocked-registrations',
+                [
+                    'authenticatedAs' => 3,
+                ]
+            )
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody()->getContents());
+
+        // assert response has pagination links
+        $this->assertObjectHasProperty('links', $body);
+        $this->assertObjectHasProperty('first', $body->links);
+
+        // assert response has data
+        $this->assertObjectHasProperty('data', $body);
+    }
+}

--- a/tests/integration/api/BlockedRegistrationsTest.php
+++ b/tests/integration/api/BlockedRegistrationsTest.php
@@ -92,7 +92,6 @@ class BlockedRegistrationsTest extends TestCase
         $this->assertEquals('spammer@machine.local', $data->attributes->email);
     }
 
-
     /**
      * @test
      */

--- a/tests/integration/api/BlockedRegistrationsTest.php
+++ b/tests/integration/api/BlockedRegistrationsTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/anti-spam.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\AntiSpam\Tests\integration\api;
 
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
@@ -34,7 +43,7 @@ class BlockedRegistrationsTest extends TestCase
     {
         $response = $this->send(
             $this->request(
-                'GET', 
+                'GET',
                 '/api/blocked-registrations',
                 [
                     'authenticatedAs' => 2,
@@ -52,7 +61,7 @@ class BlockedRegistrationsTest extends TestCase
     {
         $response = $this->send(
             $this->request(
-                'GET', 
+                'GET',
                 '/api/blocked-registrations',
                 [
                     'authenticatedAs' => 3,

--- a/tests/integration/api/SfsClientTest.php
+++ b/tests/integration/api/SfsClientTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/anti-spam.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\AntiSpam\Tests\integration\api;
 
 use Flarum\Testing\integration\TestCase;
@@ -12,7 +21,7 @@ class SfsClientTest extends TestCase
      * @var SfsClient
      */
     protected $sfsClient;
-    
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/integration/api/SfsClientTest.php
+++ b/tests/integration/api/SfsClientTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace FoF\AntiSpam\Tests\integration\api;
+
+use Flarum\Testing\integration\TestCase;
+use FoF\AntiSpam\Api\SfsClient;
+use FoF\AntiSpam\Api\SfsResponse;
+
+class SfsClientTest extends TestCase
+{
+    /**
+     * @var SfsClient
+     */
+    protected $sfsClient;
+    
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-anti-spam');
+    }
+
+    protected function setUpClient(): void
+    {
+        $this->sfsClient = $this->app()->getContainer()->make(SfsClient::class);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_check_data_and_parse_it()
+    {
+        $this->setUpClient();
+
+        $testIp = '109.104.183.88';
+        $testEmail = 'testing@xrumer.ru';
+        $testUsername = 'xrumer';
+
+        $response = $this->sfsClient->check(
+            $testIp,
+            $testEmail,
+            $testUsername
+        );
+
+        $this->assertEquals(SfsResponse::class, get_class($response));
+
+        $this->assertTrue($response->success);
+
+        $this->assertNotNull($response->ip);
+        $this->assertEquals($testIp, $response->ip->value);
+        $this->assertObjectHasProperty('confidence', $response->ip);
+        $this->assertObjectHasProperty('blacklisted', $response->ip);
+        $this->assertObjectHasProperty('asn', $response->ip);
+        $this->assertObjectHasProperty('country', $response->ip);
+
+        $this->assertNotNull($response->email);
+        $this->assertEquals($testEmail, $response->email->value);
+        $this->assertObjectHasProperty('confidence', $response->email);
+        $this->assertObjectHasProperty('blacklisted', $response->email);
+
+        $this->assertNotNull($response->username);
+        $this->assertEquals($testUsername, $response->username->value);
+        $this->assertObjectHasProperty('confidence', $response->username);
+        $this->assertObjectHasProperty('blacklisted', $response->username);
+    }
+
+    /**
+     * @test
+     */
+    public function email_is_hashed_when_setting_enabled()
+    {
+        $this->setting('fof-anti-spam.emailhash', true);
+
+        $this->setUpClient();
+
+        $testIp = '109.104.183.88';
+        $testEmail = 'testing@xrumer.ru';
+        $testUsername = 'xrumer';
+
+        $response = $this->sfsClient->check(
+            $testIp,
+            $testEmail,
+            $testUsername
+        );
+        $this->assertEquals(SfsResponse::class, get_class($response));
+
+        $this->assertTrue($response->success);
+
+        $this->assertNotNull($response->email);
+        $this->assertEquals($testEmail, $response->email->value);
+    }
+}

--- a/tests/integration/forum/RegistrationTest.php
+++ b/tests/integration/forum/RegistrationTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/anti-spam.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\AntiSpam\Tests\integration\forum;
 
 use Flarum\Extend;

--- a/tests/integration/forum/RegistrationTest.php
+++ b/tests/integration/forum/RegistrationTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace FoF\AntiSpam\Tests\integration\forum;
+
+use Flarum\Extend;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+
+class RegistrationTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-anti-spam');
+
+        $this->extend(
+            (new Extend\Csrf)->exemptRoute('register')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_register_a_new_user()
+    {
+        $response = $this->send(
+            $this->request('POST', '/register', [
+                'json' => [
+                    'username' => 'test',
+                    'password' => 'too-obscure',
+                    'email' => 'test@flarum.org',
+                ]
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        /** @var User $user */
+        $user = User::where('username', 'test')->firstOrFail();
+
+        $this->assertEquals(0, $user->is_email_confirmed);
+        $this->assertEquals('test', $user->username);
+        $this->assertEquals('test@flarum.org', $user->email);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_register_a_new_user_when_hash_is_on()
+    {
+        $this->setting('fof-anti-spam.emailhash', true);
+
+        $this->it_can_register_a_new_user();
+    }
+
+    /**
+     * @test
+     */
+    public function it_rejects_registration_from_a_known_spammer()
+    {
+        $response = $this->send(
+            $this->request('POST', '/register', [
+                'json' => [
+                    'username' => 'xrumer',
+                    'password' => 'too-obscure',
+                    'email' => 'testing@xrumer.ru',
+                ]
+            ])
+        );
+        $this->assertEquals(422, $response->getStatusCode());
+
+        $body = json_decode($response->getBody()->getContents(), true);
+        $this->assertEquals('validation_error', $body['errors'][0]['code']);
+        $this->assertEquals('/data/attributes/username', $body['errors'][0]['source']['pointer']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_rejects_registration_from_a_known_spammer_when_hash_is_on()
+    {
+        $this->setting('fof-anti-spam.emailhash', true);
+
+        $this->it_rejects_registration_from_a_known_spammer();
+    }
+}


### PR DESCRIPTION
Improved prevented registration messaging:
![image](https://github.com/FriendsOfFlarum/anti-spam/assets/16573496/901cd8b2-e13e-492b-9003-1b2c9c8918f4)


New look settings:
![image](https://github.com/FriendsOfFlarum/anti-spam/assets/16573496/fb48538d-94c2-4090-a6fe-03a0aaed0996)

New `blocked registrations`:
![image](https://github.com/FriendsOfFlarum/anti-spam/assets/16573496/af37065f-f928-4ba3-99c0-9749a9d734ba)
