### PR TITLE
[2.x] fix: hiding non comment posts causes error.

### DIFF
--- a/src/Command/MarkUserAsSpammerHandler.php
+++ b/src/Command/MarkUserAsSpammerHandler.php
@@ -13,6 +13,7 @@ namespace FoF\AntiSpam\Command;
 
 use Carbon\Carbon;
 use Flarum\Extension\ExtensionManager;
+use Flarum\Post\Post;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\Guest;
 use Flarum\User\User;
@@ -142,10 +143,14 @@ class MarkUserAsSpammerHandler
             // Bulk hide: use model methods which fire Hidden events
             $flagsEnabled = $this->flagsEnabled();
 
-            $user->posts()->where('hidden_at', null)->get()->each(function ($post) use ($actor, $flagsEnabled) {
-                /** @var \Flarum\Post\CommentPost $post */
-                $post->hide($actor);
-                $post->save();
+            $user->posts()->where('hidden_at', null)->get()->each(function (Post $post) use ($actor, $flagsEnabled) {
+                // Only hide posts that support the hide() method (e.g., CommentPost)
+                // Event posts like DiscussionTaggedPost don't have hide() method
+                if (method_exists($post, 'hide')) {
+                    /** @var \Flarum\Post\CommentPost $post */
+                    $post->hide($actor);
+                    $post->save();
+                }
 
                 if ($flagsEnabled) {
                     // Flags are deleted via the post relationship


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
First check if the `Post` subtype has the `hide()` method before calling it. This way, we will still hide any custom types if they implement the function.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
