### PR TITLE
[2.x] Fix spammer delete event handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,6 +96,7 @@
     "require-dev": {
         "flarum/testing": "^2.0.0",
         "flarum/phpstan": "^2.0.0",
+        "flarum/realtime": "^2.0.0",
         "flarum/suspend": "^2.0.0",
         "fof/user-bio": "^2.0.0",
         "flarum/tags": "^2.0.0",

--- a/src/Command/MarkUserAsSpammerHandler.php
+++ b/src/Command/MarkUserAsSpammerHandler.php
@@ -12,6 +12,7 @@
 namespace FoF\AntiSpam\Command;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Extension\ExtensionManager;
 use Flarum\Post\Post;
 use Flarum\Settings\SettingsRepositoryInterface;
@@ -23,6 +24,7 @@ use Illuminate\Contracts\Events\Dispatcher as Events;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Psr\Log\LoggerInterface;
 
 class MarkUserAsSpammerHandler
@@ -138,7 +140,10 @@ class MarkUserAsSpammerHandler
     protected function handlePosts(User $user, User $actor): void
     {
         if ($this->deletePosts) {
+            $discussionIds = $user->posts()->whereNotNull('discussion_id')->pluck('discussion_id')->unique()->values();
+
             $this->deleteModels($user->posts());
+            $this->refreshDiscussionPostMetadata($discussionIds);
         } else {
             // Bulk hide: use model methods which fire Hidden events
             $flagsEnabled = $this->flagsEnabled();
@@ -190,6 +195,31 @@ class MarkUserAsSpammerHandler
             foreach ($models as $model) {
                 $model->delete();
             }
+        });
+    }
+
+    /**
+     * @param Collection<int, int> $discussionIds
+     */
+    protected function refreshDiscussionPostMetadata(Collection $discussionIds): void
+    {
+        if ($discussionIds->isEmpty()) {
+            return;
+        }
+
+        Discussion::whereIn('id', $discussionIds)->get()->each(function (Discussion $discussion) {
+            if ($lastPost = $discussion->comments()->latest()->latest('id')->first()) {
+                $discussion->setLastPost($lastPost);
+            } else {
+                $discussion->last_posted_at = null;
+                $discussion->last_posted_user_id = null;
+                $discussion->last_post_id = null;
+                $discussion->last_post_number = null;
+            }
+
+            $discussion->refreshCommentCount();
+            $discussion->refreshParticipantCount();
+            $discussion->save();
         });
     }
 

--- a/src/Command/MarkUserAsSpammerHandler.php
+++ b/src/Command/MarkUserAsSpammerHandler.php
@@ -21,6 +21,7 @@ use FoF\AntiSpam\Event\MarkedUserAsSpammer;
 use FoF\AntiSpam\Job\ReportSpammerJob;
 use Illuminate\Contracts\Events\Dispatcher as Events;
 use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Arr;
 use Psr\Log\LoggerInterface;
 
@@ -137,8 +138,7 @@ class MarkUserAsSpammerHandler
     protected function handlePosts(User $user, User $actor): void
     {
         if ($this->deletePosts) {
-            // Bulk deletion: use direct Eloquent for performance, events still fire on model
-            $user->posts()->delete();
+            $this->deleteModels($user->posts());
         } else {
             // Bulk hide: use model methods which fire Hidden events
             $flagsEnabled = $this->flagsEnabled();
@@ -170,8 +170,7 @@ class MarkUserAsSpammerHandler
     protected function handleDiscussions(User $user, User $actor): void
     {
         if ($this->deleteDiscussions) {
-            // Bulk deletion: use direct Eloquent for performance
-            $user->discussions()->delete();
+            $this->deleteModels($user->discussions());
         } else {
             // Bulk hide: use model methods which fire Hidden events
             $user->discussions()->where('hidden_at', null)->get()->each(function ($discussion) use ($actor) {
@@ -183,6 +182,15 @@ class MarkUserAsSpammerHandler
                 $this->moveUserDiscussionsToQuarantine($user);
             }
         }
+    }
+
+    protected function deleteModels(HasMany $relation): void
+    {
+        $relation->chunkById(100, function ($models) {
+            foreach ($models as $model) {
+                $model->delete();
+            }
+        });
     }
 
     protected function moveUserDiscussionsToQuarantine(User $user): void

--- a/tests/integration/SpamblockTest.php
+++ b/tests/integration/SpamblockTest.php
@@ -42,11 +42,11 @@ class SpamblockTest extends TestCase
             ],
             Discussion::class => [
                 // Spammer's first discussion with multiple posts
-                ['id' => 2, 'title' => 'Spam Discussion 1', 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 5, 'first_post_id' => 4, 'comment_count' => 3, 'last_post_id' => 6],
+                ['id' => 2, 'title' => 'Spam Discussion 1', 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'last_posted_user_id' => 5, 'user_id' => 5, 'first_post_id' => 4, 'comment_count' => 3, 'last_post_id' => 6],
                 // Spammer's second discussion
-                ['id' => 3, 'title' => 'Spam Discussion 2', 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 5, 'first_post_id' => 7, 'comment_count' => 2, 'last_post_id' => 8],
+                ['id' => 3, 'title' => 'Spam Discussion 2', 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'last_posted_user_id' => 5, 'user_id' => 5, 'first_post_id' => 7, 'comment_count' => 2, 'last_post_id' => 8],
                 // Regular user's discussion with spammer reply
-                ['id' => 4, 'title' => 'Normal Discussion', 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 4, 'first_post_id' => 9, 'comment_count' => 2, 'last_post_id' => 10],
+                ['id' => 4, 'title' => 'Normal Discussion', 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'last_posted_user_id' => 5, 'user_id' => 4, 'first_post_id' => 9, 'comment_count' => 2, 'last_post_id' => 10],
             ],
             Post::class => [
                 // Discussion 2 - spammer's posts
@@ -214,6 +214,32 @@ class SpamblockTest extends TestCase
 
         // Note: Post #5 (normal user's reply in spammer's discussion) may or may not be cascade-deleted
         // depending on database foreign key enforcement. We only verify critical post #9 remains.
+    }
+
+    #[Test]
+    public function deleting_spammer_posts_refreshes_discussion_last_post_metadata()
+    {
+        $this->setting('fof-anti-spam.actions.deletePosts', true);
+
+        $this->app();
+
+        $discussion = Discussion::find(4);
+        $this->assertEquals(10, $discussion->last_post_id, 'Fixture should start with spam reply as last post');
+        $this->assertEquals(5, $discussion->last_posted_user_id, 'Fixture should start with spammer as last poster');
+
+        $response = $this->send(
+            $this->request('POST', 'api/users/5/spamblock', [
+                'authenticatedAs' => 3,
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertNull(CommentPost::find(10), 'Spammer reply in normal discussion should be deleted');
+
+        $discussion->refresh();
+
+        $this->assertEquals(9, $discussion->last_post_id, 'Last post should be recalculated after deleting spammer reply');
+        $this->assertEquals(4, $discussion->last_posted_user_id, 'Last poster should be recalculated after deleting spammer reply');
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- delete spammer posts and discussions through model instances instead of relationship bulk deletes
- preserve Flarum/Eloquent delete events so affected discussion metadata can be recalculated
- add a regression test for a normal discussion whose last post was a deleted spammer reply

Fixes #20.

## Tests
- `git diff --check`

Could not run PHPUnit locally because this Windows host does not have `php` or `composer` in PATH.