### PR TITLE
[2.x] Update phpunit config for Flarum 2 / PHPUnit 12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tests/.phpunit.result.cache
 .idea/*
 .vscode
 js/coverage-ts
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -99,6 +99,7 @@
         "flarum/suspend": "^2.0.0",
         "fof/user-bio": "^2.0.0",
         "flarum/tags": "^2.0.0",
-        "fof/oauth": "^2.0.0"
+        "fof/oauth": "^2.0.0",
+        "flarum/realtime": "^2.0.0"
     }
 }

--- a/tests/integration/StopForumSpamTest.php
+++ b/tests/integration/StopForumSpamTest.php
@@ -25,12 +25,12 @@ class StopForumSpamTest extends TestCase
         $this->extension('flarum-flags', 'flarum-approval', 'fof-anti-spam');
     }
 
-    private function createMockSfsClient(SfsResponse $response): SfsClient
+    private function createStubSfsClient(SfsResponse $response): SfsClient
     {
-        $mock = $this->createMock(SfsClient::class);
-        $mock->method('check')->willReturn($response);
+        $stub = $this->createStub(SfsClient::class);
+        $stub->method('check')->willReturn($response);
 
-        return $mock;
+        return $stub;
     }
 
     private function createSfsResponse(array $data): SfsResponse
@@ -62,7 +62,7 @@ class StopForumSpamTest extends TestCase
             ],
         ]);
 
-        $client = $this->createMockSfsClient($sfsResponse);
+        $client = $this->createStubSfsClient($sfsResponse);
         $settings = $this->app()->getContainer()->make('flarum.settings');
         $dispatcher = $this->app()->getContainer()->make('events');
 
@@ -96,7 +96,7 @@ class StopForumSpamTest extends TestCase
             ],
         ]);
 
-        $client = $this->createMockSfsClient($sfsResponse);
+        $client = $this->createStubSfsClient($sfsResponse);
         $settings = $this->app()->getContainer()->make('flarum.settings');
         $dispatcher = $this->app()->getContainer()->make('events');
 
@@ -130,7 +130,7 @@ class StopForumSpamTest extends TestCase
             ],
         ]);
 
-        $client = $this->createMockSfsClient($sfsResponse);
+        $client = $this->createStubSfsClient($sfsResponse);
         $settings = $this->app()->getContainer()->make('flarum.settings');
         $dispatcher = $this->app()->getContainer()->make('events');
 
@@ -162,7 +162,7 @@ class StopForumSpamTest extends TestCase
             ],
         ]);
 
-        $client = $this->createMockSfsClient($sfsResponse);
+        $client = $this->createStubSfsClient($sfsResponse);
         $settings = $this->app()->getContainer()->make('flarum.settings');
         $dispatcher = $this->app()->getContainer()->make('events');
 
@@ -203,7 +203,7 @@ class StopForumSpamTest extends TestCase
             ],
         ]);
 
-        $client = $this->createMockSfsClient($sfsResponse);
+        $client = $this->createStubSfsClient($sfsResponse);
         $settings = $this->app()->getContainer()->make('flarum.settings');
         $dispatcher = $this->app()->getContainer()->make('events');
 

--- a/tests/phpunit.integration.xml
+++ b/tests/phpunit.integration.xml
@@ -1,25 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="true"
     stopOnFailure="false"
 >
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">../src/</directory>
         </include>
-    </coverage>
+    </source>
     <testsuites>
         <testsuite name="Flarum Integration Tests">
             <directory suffix="Test.php">./integration</directory>
-             <exclude>./integration/tmp</exclude>
+            <exclude>./integration/tmp</exclude>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/phpunit.unit.xml
+++ b/tests/phpunit.unit.xml
@@ -1,27 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
 >
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">../src/</directory>
         </include>
-    </coverage>
+    </source>
     <testsuites>
         <testsuite name="Flarum Unit Tests">
             <directory suffix="Test.php">./unit</directory>
         </testsuite>
     </testsuites>
-    <listeners>
-        <listener class="\Mockery\Adapter\Phpunit\TestListener" />
-    </listeners>
 </phpunit>


### PR DESCRIPTION
Updates `tests/phpunit.unit.xml` and `tests/phpunit.integration.xml` to the PHPUnit 12 schema (matching the Flarum 2 workbench format):

- Local vendor schema, `cacheDirectory`, `backupStaticProperties`
- Drop removed `convert*ToExceptions` attributes and the Mockery listener
- `<coverage>` → `<source>`

Also switches the `SfsClient` test double in `StopForumSpamTest` from a mock to a stub to clear the PHPUnit 12 "no expectations configured" notices.