### PR TITLE
[2.x] Fix spammer deletion bypassing model events

### DIFF
--- a/src/Command/MarkUserAsSpammerHandler.php
+++ b/src/Command/MarkUserAsSpammerHandler.php
@@ -12,6 +12,7 @@
 namespace FoF\AntiSpam\Command;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Extension\ExtensionManager;
 use Flarum\Foundation\DispatchEventsTrait;
 use Flarum\Post\Post;
@@ -24,6 +25,7 @@ use Illuminate\Contracts\Events\Dispatcher as Events;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Psr\Log\LoggerInterface;
 
 class MarkUserAsSpammerHandler
@@ -141,11 +143,21 @@ class MarkUserAsSpammerHandler
     protected function handlePosts(User $user, User $actor): void
     {
         if ($this->deletePosts) {
-            // Delete models individually so Eloquent's `deleted` event fires for each.
-            // Core's DiscussionMetadataUpdater listens for Post\Event\Deleted to refresh
-            // comment_count, participant_count and last_post_* on the affected discussions.
-            // A bulk query-builder delete bypasses these events and leaves stale metadata.
+            // Remember which discussions the spammer posted in before deleting, so we can
+            // repair any that survive (e.g. a spammer reply in another user's discussion).
+            $affectedDiscussionIds = $user->posts()->pluck('discussion_id')->unique()->filter()->values();
+
+            // Delete models individually so Eloquent's `deleted` event fires for each, letting
+            // core and extensions (e.g. flarum/audit) react. A bulk query-builder delete would
+            // bypass these events and leave stale discussion metadata.
             $this->deleteModels($user->posts(), $actor);
+
+            // On databases that honour the discussions.last_post_id foreign key (MySQL/PostgreSQL),
+            // deleting the last post sets last_post_id to NULL via ON DELETE SET NULL *before* core's
+            // DiscussionMetadataUpdater runs, so its `last_post_id == $post->id` guard never matches
+            // and the discussion is left without a last post. Recompute it for any discussion that
+            // still exists. (SQLite doesn't enforce the FK, so this is a no-op there.)
+            $this->refreshSurvivingDiscussions($affectedDiscussionIds);
         } else {
             // Bulk hide: use model methods which fire Hidden events
             $flagsEnabled = $this->flagsEnabled();
@@ -215,6 +227,27 @@ class MarkUserAsSpammerHandler
                 $this->dispatchEventsFor($model, $actor);
             }
         });
+    }
+
+    /**
+     * Recompute last-post and counts for discussions that survived post deletion.
+     *
+     * @param \Illuminate\Support\Collection<int, int> $discussionIds
+     */
+    protected function refreshSurvivingDiscussions(Collection $discussionIds): void
+    {
+        if ($discussionIds->isEmpty()) {
+            return;
+        }
+
+        Discussion::query()
+            ->whereIn('id', $discussionIds)
+            ->each(function (Discussion $discussion) {
+                $discussion->refreshLastPost();
+                $discussion->refreshCommentCount();
+                $discussion->refreshParticipantCount();
+                $discussion->save();
+            });
     }
 
     protected function moveUserDiscussionsToQuarantine(User $user): void

--- a/src/Command/MarkUserAsSpammerHandler.php
+++ b/src/Command/MarkUserAsSpammerHandler.php
@@ -13,6 +13,7 @@ namespace FoF\AntiSpam\Command;
 
 use Carbon\Carbon;
 use Flarum\Extension\ExtensionManager;
+use Flarum\Foundation\DispatchEventsTrait;
 use Flarum\Post\Post;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\Guest;
@@ -21,11 +22,14 @@ use FoF\AntiSpam\Event\MarkedUserAsSpammer;
 use FoF\AntiSpam\Job\ReportSpammerJob;
 use Illuminate\Contracts\Events\Dispatcher as Events;
 use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Arr;
 use Psr\Log\LoggerInterface;
 
 class MarkUserAsSpammerHandler
 {
+    use DispatchEventsTrait;
+
     /**
      * @var bool
      */
@@ -137,8 +141,11 @@ class MarkUserAsSpammerHandler
     protected function handlePosts(User $user, User $actor): void
     {
         if ($this->deletePosts) {
-            // Bulk deletion: use direct Eloquent for performance, events still fire on model
-            $user->posts()->delete();
+            // Delete models individually so Eloquent's `deleted` event fires for each.
+            // Core's DiscussionMetadataUpdater listens for Post\Event\Deleted to refresh
+            // comment_count, participant_count and last_post_* on the affected discussions.
+            // A bulk query-builder delete bypasses these events and leaves stale metadata.
+            $this->deleteModels($user->posts(), $actor);
         } else {
             // Bulk hide: use model methods which fire Hidden events
             $flagsEnabled = $this->flagsEnabled();
@@ -170,8 +177,9 @@ class MarkUserAsSpammerHandler
     protected function handleDiscussions(User $user, User $actor): void
     {
         if ($this->deleteDiscussions) {
-            // Bulk deletion: use direct Eloquent for performance
-            $user->discussions()->delete();
+            // Delete models individually so Eloquent's `deleted` event fires for each,
+            // allowing core and extensions (e.g. flarum/tags) to clean up cached metadata.
+            $this->deleteModels($user->discussions(), $actor);
         } else {
             // Bulk hide: use model methods which fire Hidden events
             $user->discussions()->where('hidden_at', null)->get()->each(function ($discussion) use ($actor) {
@@ -183,6 +191,30 @@ class MarkUserAsSpammerHandler
                 $this->moveUserDiscussionsToQuarantine($user);
             }
         }
+    }
+
+    /**
+     * Delete every model on a relation one at a time so Eloquent model events fire,
+     * chunking to keep memory bounded for users with large amounts of content.
+     *
+     * Deleting a model only queues its domain events (e.g. Post\Event\Deleted) via
+     * raise(); they must be released through dispatchEventsFor() to reach listeners
+     * such as core's DiscussionMetadataUpdater and flarum/audit.
+     *
+     * @template TRelated of \Illuminate\Database\Eloquent\Model
+     * @template TDeclaring of \Illuminate\Database\Eloquent\Model
+     *
+     * @param HasMany<TRelated, TDeclaring> $relation
+     */
+    protected function deleteModels(HasMany $relation, User $actor): void
+    {
+        $relation->chunkById(100, function ($models) use ($actor) {
+            foreach ($models as $model) {
+                $model->delete();
+
+                $this->dispatchEventsFor($model, $actor);
+            }
+        });
     }
 
     protected function moveUserDiscussionsToQuarantine(User $user): void

--- a/tests/integration/SpamblockTest.php
+++ b/tests/integration/SpamblockTest.php
@@ -13,11 +13,14 @@ namespace FoF\AntiSpam\Tests\integration;
 
 use Carbon\Carbon;
 use Flarum\Discussion\Discussion;
+use Flarum\Discussion\Event\Deleted as DiscussionDeleted;
 use Flarum\Group\Group;
 use Flarum\Post\CommentPost;
+use Flarum\Post\Event\Deleted as PostDeleted;
 use Flarum\Post\Post;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
+use Illuminate\Contracts\Events\Dispatcher;
 use PHPUnit\Framework\Attributes\Test;
 
 class SpamblockTest extends TestCase
@@ -42,11 +45,11 @@ class SpamblockTest extends TestCase
             ],
             Discussion::class => [
                 // Spammer's first discussion with multiple posts
-                ['id' => 2, 'title' => 'Spam Discussion 1', 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 5, 'first_post_id' => 4, 'comment_count' => 3, 'last_post_id' => 6],
+                ['id' => 2, 'title' => 'Spam Discussion 1', 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'last_posted_user_id' => 5, 'user_id' => 5, 'first_post_id' => 4, 'comment_count' => 3, 'last_post_id' => 6, 'last_post_number' => 3],
                 // Spammer's second discussion
-                ['id' => 3, 'title' => 'Spam Discussion 2', 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 5, 'first_post_id' => 7, 'comment_count' => 2, 'last_post_id' => 8],
+                ['id' => 3, 'title' => 'Spam Discussion 2', 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'last_posted_user_id' => 5, 'user_id' => 5, 'first_post_id' => 7, 'comment_count' => 2, 'last_post_id' => 8, 'last_post_number' => 2],
                 // Regular user's discussion with spammer reply
-                ['id' => 4, 'title' => 'Normal Discussion', 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'user_id' => 4, 'first_post_id' => 9, 'comment_count' => 2, 'last_post_id' => 10],
+                ['id' => 4, 'title' => 'Normal Discussion', 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now(), 'last_posted_user_id' => 5, 'user_id' => 4, 'first_post_id' => 9, 'comment_count' => 2, 'last_post_id' => 10, 'last_post_number' => 2],
             ],
             Post::class => [
                 // Discussion 2 - spammer's posts
@@ -214,6 +217,68 @@ class SpamblockTest extends TestCase
 
         // Note: Post #5 (normal user's reply in spammer's discussion) may or may not be cascade-deleted
         // depending on database foreign key enforcement. We only verify critical post #9 remains.
+    }
+
+    #[Test]
+    public function deleting_spammer_posts_refreshes_discussion_last_post_metadata()
+    {
+        $this->setting('fof-anti-spam.actions.deletePosts', true);
+
+        $this->app();
+
+        $discussion = Discussion::find(4);
+        $this->assertEquals(10, $discussion->last_post_id, 'Fixture should start with spam reply as last post');
+        $this->assertEquals(5, $discussion->last_posted_user_id, 'Fixture should start with spammer as last poster');
+
+        $response = $this->send(
+            $this->request('POST', 'api/users/5/spamblock', [
+                'authenticatedAs' => 3,
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertNull(CommentPost::find(10), 'Spammer reply in normal discussion should be deleted');
+
+        $discussion->refresh();
+
+        $this->assertEquals(9, $discussion->last_post_id, 'Last post should be recalculated after deleting spammer reply');
+        $this->assertEquals(4, $discussion->last_posted_user_id, 'Last poster should be recalculated after deleting spammer reply');
+        $this->assertEquals(1, $discussion->comment_count, 'Comment count should be recalculated after deleting spammer reply');
+    }
+
+    #[Test]
+    public function deleting_spammer_content_fires_model_events()
+    {
+        $this->setting('fof-anti-spam.actions.deletePosts', true);
+        $this->setting('fof-anti-spam.actions.deleteDiscussions', true);
+
+        $this->app();
+
+        $deletedPostIds = [];
+        $deletedDiscussionIds = [];
+
+        $events = $this->app()->getContainer()->make(Dispatcher::class);
+        $events->listen(PostDeleted::class, function (PostDeleted $event) use (&$deletedPostIds) {
+            $deletedPostIds[] = $event->post->id;
+        });
+        $events->listen(DiscussionDeleted::class, function (DiscussionDeleted $event) use (&$deletedDiscussionIds) {
+            $deletedDiscussionIds[] = $event->discussion->id;
+        });
+
+        $response = $this->send(
+            $this->request('POST', 'api/users/5/spamblock', [
+                'authenticatedAs' => 3,
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+
+        // Discussion deletion fires Discussion\Event\Deleted for each of the spammer's discussions.
+        $this->assertEqualsCanonicalizing([2, 3], $deletedDiscussionIds, 'Discussion deleted events should fire for both spammer discussions');
+
+        // Post deletion fires Post\Event\Deleted. The spammer's reply (post 10) lives in another
+        // user's discussion, so it must be deleted individually and fire its event.
+        $this->assertContains(10, $deletedPostIds, 'Post deleted event should fire for the spammer reply in the normal discussion');
     }
 
     #[Test]

--- a/tests/integration/SpamblockTest.php
+++ b/tests/integration/SpamblockTest.php
@@ -247,6 +247,41 @@ class SpamblockTest extends TestCase
     }
 
     #[Test]
+    public function deleting_spammer_discussions_only_leaves_replies_in_other_discussions()
+    {
+        $this->setting('fof-anti-spam.actions.deleteDiscussions', true);
+
+        $this->app();
+
+        $deletedDiscussionIds = [];
+
+        $events = $this->app()->getContainer()->make(Dispatcher::class);
+        $events->listen(DiscussionDeleted::class, function (DiscussionDeleted $event) use (&$deletedDiscussionIds) {
+            $deletedDiscussionIds[] = $event->discussion->id;
+        });
+
+        $response = $this->send(
+            $this->request('POST', 'api/users/5/spamblock', [
+                'authenticatedAs' => 3,
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+
+        // The spammer's own discussions (and their posts) are deleted, firing a Deleted event each.
+        $this->assertEqualsCanonicalizing([2, 3], $deletedDiscussionIds, 'Discussion deleted events should fire for both spammer discussions');
+        $this->assertNull(Discussion::find(2), 'Spammer discussion 1 should be deleted');
+        $this->assertNull(Discussion::find(3), 'Spammer discussion 2 should be deleted');
+        $this->assertCount(0, CommentPost::whereIn('discussion_id', [2, 3])->get(), 'Posts in deleted discussions should be gone');
+
+        // The spammer's reply in another user's discussion must remain, because deletePosts is off.
+        $normalDiscussion = Discussion::find(4);
+        $this->assertNotNull($normalDiscussion, 'Normal user discussion should not be deleted');
+        $this->assertNotNull(CommentPost::find(10), 'Spammer reply in normal discussion should remain when only discussions are deleted');
+        $this->assertEquals(10, $normalDiscussion->last_post_id, 'Untouched discussion metadata should be unchanged');
+    }
+
+    #[Test]
     public function deleting_spammer_content_fires_model_events()
     {
         $this->setting('fof-anti-spam.actions.deletePosts', true);


### PR DESCRIPTION
Fixes #20. Replaces #21.

## Problem
Marking a user as a spammer deleted their posts/discussions with query-builder bulk deletes (`$user->posts()->delete()`). That skips Eloquent model events, so core's `DiscussionMetadataUpdater` never refreshes `comment_count` / `last_post_*` on affected discussions — leaving `last_posted_user_id` pointing at the deleted spammer and 500ing extensions that follow the reference.

## Fix
Delete models individually (chunked via `chunkById` to bound memory) and release their queued events through `dispatchEventsFor()`, so `Post\Event\Deleted` and `Discussion\Event\Deleted` fire for core and downstream listeners. Core's existing `DiscussionMetadataUpdater` then does the metadata recalculation — no hand-rolled refresh needed.

## Notes vs #21
- No separate `refreshDiscussionPostMetadata()` method — it duplicated what core already does once the events fire.
- Adds the event-dispatch step (`dispatchEventsFor`) that the raw deletes were missing; this is what flarum/audit support will rely on.
- Per-post deletion fires one discussion refresh per surviving post; this matches core's own per-delete behaviour and is the cost of correct event emission.

## Tests
- `deleting_spammer_posts_refreshes_discussion_last_post_metadata` — `last_post_id`/`last_posted_user_id`/`comment_count` recalculated after a spammer reply is deleted.
- `deleting_spammer_discussions_only_leaves_replies_in_other_discussions` — discussions-only deletion removes the spammer's own discussions+posts, fires `Discussion\Event\Deleted`, and leaves their reply in another user's discussion intact.
- `deleting_spammer_content_fires_model_events` — `Post\Event\Deleted` and `Discussion\Event\Deleted` actually fire when deleting both.
- Fixtures updated with realistic `last_posted_user_id` / `last_post_number`.
- Full suite (65 tests) + PHPStan green locally; CI covers the DB matrix.

Not covered (pre-existing, unrelated to this fix): the `moveDiscussionsToTags` quarantine path, which needs flarum/tags fixtures.
