### PR TITLE
[2.x] feat: flarum/audit integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
             },
             "optional-dependencies": [
                 "flarum/suspend",
-                "flarum/tags"
+                "flarum/tags",
+                "flarum/audit"
             ]
         },
         "flarum-cli": {
@@ -100,6 +101,7 @@
         "fof/user-bio": "^2.0.0",
         "flarum/tags": "^2.0.0",
         "fof/oauth": "^2.0.0",
-        "flarum/realtime": "^2.0.0"
+        "flarum/realtime": "^2.0.0",
+        "flarum/audit": "2.x-dev"
     }
 }

--- a/extend.php
+++ b/extend.php
@@ -13,8 +13,11 @@ namespace FoF\AntiSpam;
 
 use Flarum\Api\Resource\ForumResource;
 use Flarum\Api\Resource\UserResource;
+use Flarum\Audit\Extend\Audit;
 use Flarum\Extend;
 use Flarum\User\User;
+use FoF\AntiSpam\Event\MarkedUserAsSpammer;
+use FoF\AntiSpam\Event\RegistrationWasBlocked;
 
 return [
     (new Extend\Frontend('forum'))
@@ -78,4 +81,17 @@ return [
         ->subscribe(Listener\CheckDiscussionContent::class),
 
     new Extend\ApiResource(Api\Resource\BlockedRegistrationResource::class),
+
+    (new Extend\Conditional())
+        ->whenExtensionEnabled('flarum-audit', fn () => [
+            (new Audit())
+                ->listen(MarkedUserAsSpammer::class, 'user.marked_as_spammer', fn (MarkedUserAsSpammer $e) => [
+                    'user_id' => $e->user->id,
+                ])
+                ->listen(RegistrationWasBlocked::class, 'registration.blocked', fn (RegistrationWasBlocked $e) => [
+                    'ip' => $e->blocked->ip,
+                    'email' => $e->blocked->email,
+                    'username' => $e->blocked->username,
+                ]),
+        ]),
 ];

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -142,3 +142,13 @@ fof-anti-spam:
       report_to_sfs_help: This will report the user's basic details (username, email, IP address) to StopForumSpam. This will help prevent the user from registering on other forums that use the StopForumSpam service.
     user_controls:
       spammer_button: Spammer
+
+# Audit log action labels, contributed to the flarum/audit namespace.
+# Rendered by flarum-audit at flarum-audit.lib.browser.<action>.
+flarum-audit:
+  lib:
+    browser:
+      user:
+        marked_as_spammer: Marked {username} as a spammer
+      registration:
+        blocked: Blocked registration for {username} ({email}) from {ip}

--- a/tests/integration/AuditTest.php
+++ b/tests/integration/AuditTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of fof/anti-spam.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\AntiSpam\Tests\integration;
+
+use Flarum\Audit\AuditLog;
+use Flarum\Audit\AuditLogger;
+use Flarum\Group\Group;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use FoF\AntiSpam\Event\RegistrationWasBlocked;
+use FoF\AntiSpam\Model\BlockedRegistration;
+use Illuminate\Contracts\Events\Dispatcher;
+use PHPUnit\Framework\Attributes\Test;
+
+class AuditTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Log lifecycle events fired outside the test transaction shouldn't create stray entries.
+        AuditLogger::$testMode = true;
+
+        $this->extension('flarum-audit', 'fof-anti-spam');
+
+        $this->prepareDatabase([
+            'audit_log' => [],
+            User::class => [
+                ['id' => 3, 'username' => 'a_moderator', 'email' => 'a_mod@machine.local', 'is_email_confirmed' => 1],
+                ['id' => 5, 'username' => 'bad_user', 'email' => 'bad_user@machine.local', 'is_email_confirmed' => 1],
+            ],
+            'group_user' => [
+                ['user_id' => 3, 'group_id' => Group::MODERATOR_ID],
+            ],
+            'group_permission' => [
+                ['group_id' => Group::MODERATOR_ID, 'permission' => 'user.spamblock'],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function marking_user_as_spammer_is_logged()
+    {
+        $response = $this->send(
+            $this->request('POST', 'api/users/5/spamblock', [
+                'authenticatedAs' => 3,
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+
+        $log = AuditLog::query()->where('action', 'user.marked_as_spammer')->first();
+
+        $this->assertNotNull($log, 'Marking a user as a spammer should be audit logged');
+        $this->assertEquals(3, $log->actor_id, 'The acting moderator should be recorded');
+        $this->assertEquals(['user_id' => 5], $log->payload);
+    }
+
+    #[Test]
+    public function blocked_registration_is_logged()
+    {
+        $this->app();
+
+        $blocked = BlockedRegistration::create('1.2.3.4', 'spammer@example.com', 'spammer', '{}');
+
+        $this->app()->getContainer()->make(Dispatcher::class)->dispatch(
+            new RegistrationWasBlocked($blocked)
+        );
+
+        $log = AuditLog::query()->where('action', 'registration.blocked')->first();
+
+        $this->assertNotNull($log, 'A blocked registration should be audit logged');
+        $this->assertEquals([
+            'ip' => '1.2.3.4',
+            'email' => 'spammer@example.com',
+            'username' => 'spammer',
+        ], $log->payload);
+    }
+}


### PR DESCRIPTION
Adds [flarum/audit](https://github.com/flarum/audit) integration so spammer actions are recorded in the audit log when that extension is enabled.

## What's logged
Via the public `Flarum\Audit\Extend\Audit` extender, behind `(new Conditional())->whenExtensionEnabled('flarum-audit', ...)` so it's a no-op when audit isn't installed:

- **`user.marked_as_spammer`** — payload `{ user_id }` (audit resolves the username from `user_id`).
- **`registration.blocked`** — payload `{ ip, email, username }`.

Action labels are contributed under the `flarum-audit.lib.browser.*` locale namespace in `locale/en.yml`.

## Dependency
`flarum/audit` is untagged for 2.x, so it's added as a dev dependency on `2.x-dev`.

## Tests
- `AuditTest::marking_user_as_spammer_is_logged` — drives the real spamblock API endpoint and asserts the log entry, actor, and payload.
- `AuditTest::blocked_registration_is_logged` — dispatches `RegistrationWasBlocked` and asserts the logged payload.
- Full suite (67 tests) + PHPStan green locally on both SQLite and MySQL.
