### PR TITLE
[2.x] fix: unapproved spam first post leaves discussion visible

### DIFF
--- a/src/Listener/AbstractContentCheck.php
+++ b/src/Listener/AbstractContentCheck.php
@@ -146,10 +146,24 @@ abstract class AbstractContentCheck
 
     /**
      * Unapprove content (post or discussion).
+     *
+     * When the entity is a discussion's first post, the discussion is unapproved too — otherwise
+     * the post is held for approval but the thread stays publicly visible. This mirrors core
+     * approval's UnapproveNewContent. The post number isn't reliably set until the row is saved,
+     * so the discussion is unapproved in an afterSave hook.
      */
     protected function unapprove(Discussion|Post $entity): void
     {
         $entity->is_approved = false;
+
+        if ($entity instanceof Post) {
+            $entity->afterSave(function (Post $post) {
+                if ($post->number == 1 && $post->discussion && $post->discussion->is_approved) {
+                    $post->discussion->is_approved = false;
+                    $post->discussion->save();
+                }
+            });
+        }
     }
 
     /**

--- a/tests/integration/ContentFilterTest.php
+++ b/tests/integration/ContentFilterTest.php
@@ -12,6 +12,7 @@
 namespace FoF\AntiSpam\Tests\integration;
 
 use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
 use Flarum\Flags\Flag;
 use Flarum\Post\Post;
 use Flarum\Testing\integration\TestCase;
@@ -139,6 +140,49 @@ class ContentFilterTest extends TestCase
         $flag = Flag::where('post_id', $post->id)->where('type', 'spam')->first();
         $this->assertNotNull($flag, 'Post should be flagged as spam');
         $this->assertStringContainsString('url', strtolower($flag->reason_detail), 'Flag reason should mention URL');
+    }
+
+    #[Test]
+    public function unapproving_spam_opening_post_also_unapproves_the_discussion()
+    {
+        // A spam opening post must take its discussion down with it. Otherwise the post is held
+        // for approval but the discussion stays public, so the thread (and any moderation replies)
+        // remain visible to everyone.
+        $this->setting('fof-anti-spam.content-filter.flag_threshold', 20);
+        $this->setting('fof-anti-spam.content-filter.spam_threshold', 20);
+
+        $response = $this->send(
+            $this->request('POST', '/api/discussions', [
+                'authenticatedAs' => 3,
+                'json' => [
+                    'data' => [
+                        'type' => 'discussions',
+                        'attributes' => [
+                            'title' => 'Totally innocent title',
+                            'content' => 'Contact me at +1234567890 for details',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $post = Post::where('user_id', 3)->orderBy('id', 'desc')->first();
+        $this->assertNotNull($post, 'Post should be created');
+        $this->assertFalse((bool) $post->is_approved, 'Spam opening post should be unapproved');
+
+        $discussion = Discussion::find($post->discussion_id);
+        $this->assertNotNull($discussion);
+        $this->assertFalse((bool) $discussion->is_approved, 'Discussion started by a spam opening post should be unapproved too');
+
+        // A normal user must not be able to see the unapproved discussion.
+        $response = $this->send(
+            $this->request('GET', '/api/discussions/'.$discussion->id, [
+                'authenticatedAs' => 4,
+            ])
+        );
+        $this->assertEquals(404, $response->getStatusCode(), 'Unapproved spam discussion should not be visible to others');
     }
 
     #[Test]


### PR DESCRIPTION
Reported by a moderator: when the content filter holds a new user's opening post for approval, the **post** is unapproved but the **discussion** stays public — so the thread, and any moderation replies posted afterwards, remain visible to everyone.

## Cause
The content filter's `unapprove()` only set `post.is_approved = false`. For a discussion's first post, the discussion's own `is_approved` was left untouched, so the thread stayed visible. Core approval's `UnapproveNewContent` handles this by also unapproving the discussion when the first post is unapproved; anti-spam's filter didn't.

## Trigger
Not limited to obviously spammy content. `shouldUnapprove` is score-based, and the fresh-user / low-post-count rule only decides *whether* detectors run — so a monitored user whose opening post contains a URL, phone number, email, or matches a pattern/blocked word can trip it. The fix is at the `unapprove()` sink, so it covers every trigger uniformly.

## Fix
When unapproving a first post (`number == 1`), also unapprove its discussion, in an `afterSave` hook (the post number isn't reliably set until the row is saved). Guarded so it only acts on first posts and only when the discussion is still approved.

## Tests
- `unapproving_spam_opening_post_also_unapproves_the_discussion` — written failing first; asserts the post is unapproved, the discussion is unapproved, and a normal user gets a 404 on the discussion.
- Full suite (68 tests) + PHPStan green locally on both SQLite and MySQL.
