### PR TITLE
[2.x] fix: domain allowlist configured in admin UI is silently ignored

### DIFF
--- a/src/ContentFilter/ConfigurationManager.php
+++ b/src/ContentFilter/ConfigurationManager.php
@@ -11,6 +11,7 @@
 
 namespace FoF\AntiSpam\ContentFilter;
 
+use Flarum\Foundation\Config;
 use Flarum\Settings\SettingsRepositoryInterface;
 
 /**
@@ -28,7 +29,8 @@ class ConfigurationManager
     private array $codeConfig = [];
 
     public function __construct(
-        private SettingsRepositoryInterface $settings
+        private SettingsRepositoryInterface $settings,
+        private Config $config
     ) {
     }
 
@@ -88,19 +90,16 @@ class ConfigurationManager
     public function getAllowedDomains(): array
     {
         $codeDomains = $this->codeConfig['allowed_domains'] ?? [];
-        $dbDomains = json_decode(
-            $this->settings->get(self::PREFIX.'allowed_domains', '[]'),
-            true
-        );
+        $dbDomains = $this->getDatabaseConfiguredDomains();
 
-        // Always include the forum's own domain
-        $forumUrl = $this->settings->get('forum_url', '');
-        $forumDomain = parse_url($forumUrl, PHP_URL_HOST);
+        // Always include the forum's own domain. The base URL lives in config.php (exposed via
+        // Flarum\Foundation\Config), not the settings table.
+        $forumDomain = $this->config->url()->getHost();
 
         $allDomains = array_merge(
             $codeDomains,
-            is_array($dbDomains) ? $dbDomains : [],
-            $forumDomain ? [$forumDomain] : []
+            $dbDomains,
+            $forumDomain ? [self::normalizeDomain($forumDomain)] : []
         );
 
         return array_values(array_unique(array_filter($allDomains)));
@@ -123,12 +122,62 @@ class ConfigurationManager
      */
     public function getDatabaseConfiguredDomains(): array
     {
-        $domains = json_decode(
-            $this->settings->get(self::PREFIX.'allowed_domains', '[]'),
-            true
+        return $this->parseDomainList(
+            (string) $this->settings->get(self::PREFIX.'allowed_domains', '')
         );
+    }
 
-        return is_array($domains) ? $domains : [];
+    /**
+     * Parse a stored allowed-domains value into a normalized list of bare hostnames.
+     *
+     * The admin UI saves the textarea newline-separated (one domain per line), matching the
+     * blocked_words convention. A JSON array is also tolerated for installs that hand-wrote one
+     * to work around the historic parsing bug (see issue #22).
+     *
+     * @return array<string>
+     */
+    private function parseDomainList(string $raw): array
+    {
+        $raw = trim($raw);
+
+        if ($raw === '') {
+            return [];
+        }
+
+        // Tolerate JSON arrays (manual workarounds / legacy values).
+        if (str_starts_with($raw, '[')) {
+            $decoded = json_decode($raw, true);
+
+            if (is_array($decoded)) {
+                return array_values(array_filter(array_map(
+                    fn ($domain) => self::normalizeDomain((string) $domain),
+                    $decoded
+                )));
+            }
+        }
+
+        return array_values(array_filter(array_map(
+            fn (string $line) => self::normalizeDomain($line),
+            explode("\n", $raw)
+        )));
+    }
+
+    /**
+     * Normalize a domain entry to a bare lowercase hostname so pasted URLs and mixed case still
+     * match the URL detector's host comparison. Shared with Extend\ContentFilter.
+     */
+    public static function normalizeDomain(string $domain): string
+    {
+        // Remove protocol if present
+        $domain = preg_replace('~^https?://~i', '', $domain);
+
+        // Remove path if present
+        $domain = explode('/', $domain)[0];
+
+        // Remove port if present
+        $domain = explode(':', $domain)[0];
+
+        return strtolower(trim($domain));
     }
 
     /**

--- a/src/Extend/ContentFilter.php
+++ b/src/Extend/ContentFilter.php
@@ -246,16 +246,7 @@ class ContentFilter implements ExtenderInterface
      */
     private function normalizeDomain(string $domain): string
     {
-        // Remove protocol if present
-        $domain = preg_replace('~^https?://~i', '', $domain);
-
-        // Remove path if present
-        $domain = explode('/', $domain)[0];
-
-        // Remove port if present
-        $domain = explode(':', $domain)[0];
-
-        return strtolower(trim($domain));
+        return ConfigurationManager::normalizeDomain($domain);
     }
 
     public function extend(Container $container, ?Extension $extension = null): void

--- a/src/Providers/ContentFilterProvider.php
+++ b/src/Providers/ContentFilterProvider.php
@@ -12,6 +12,7 @@
 namespace FoF\AntiSpam\Providers;
 
 use Flarum\Foundation\AbstractServiceProvider;
+use Flarum\Foundation\Config;
 use FoF\AntiSpam\ContentFilter\Analyzer;
 use FoF\AntiSpam\ContentFilter\ConfigurationManager;
 use FoF\AntiSpam\ContentFilter\Detectors\EmailDetector;
@@ -29,7 +30,8 @@ class ContentFilterProvider extends AbstractServiceProvider
         // Register ConfigurationManager as singleton
         $this->container->singleton(ConfigurationManager::class, function ($container) {
             return new ConfigurationManager(
-                $container->make('flarum.settings')
+                $container->make('flarum.settings'),
+                $container->make(Config::class)
             );
         });
 

--- a/tests/integration/ContentFilterConfigurationTest.php
+++ b/tests/integration/ContentFilterConfigurationTest.php
@@ -126,11 +126,8 @@ class ContentFilterConfigurationTest extends TestCase
     #[Test]
     public function domain_allowlist_merges_code_and_database()
     {
-        // Database domains
-        $this->setting('fof-anti-spam.content-filter.allowed_domains', json_encode([
-            'example.com',
-            'test.com',
-        ]));
+        // Database domains, stored newline-separated as the admin UI textarea saves them.
+        $this->setting('fof-anti-spam.content-filter.allowed_domains', "example.com\ntest.com");
 
         // Code domains
         $this->extend(
@@ -150,9 +147,44 @@ class ContentFilterConfigurationTest extends TestCase
         $this->assertContains('test.com', $allDomains, 'Should include database domain');
         $this->assertContains('youtube.com', $allDomains, 'Should include code domain');
         $this->assertContains('github.com', $allDomains, 'Should include code domain');
+    }
 
-        // Should have 4 unique domains
-        $this->assertCount(4, array_unique($allDomains));
+    #[Test]
+    public function database_allowlist_accepts_json_for_backward_compatibility()
+    {
+        // Installs that worked around the parsing bug by hand-writing JSON should keep working.
+        $this->setting('fof-anti-spam.content-filter.allowed_domains', json_encode([
+            'example.com',
+            'test.com',
+        ]));
+
+        $this->app();
+
+        /** @var ConfigurationManager $config */
+        $config = $this->app()->getContainer()->make(ConfigurationManager::class);
+
+        $domains = $config->getDatabaseConfiguredDomains();
+
+        $this->assertContains('example.com', $domains);
+        $this->assertContains('test.com', $domains);
+    }
+
+    #[Test]
+    public function database_allowlist_normalizes_pasted_values()
+    {
+        // Admins paste full URLs and mixed case; these must still match the detector's
+        // bare lowercase host comparison.
+        $this->setting('fof-anti-spam.content-filter.allowed_domains', "https://YouTube.com/\n  github.com  ");
+
+        $this->app();
+
+        /** @var ConfigurationManager $config */
+        $config = $this->app()->getContainer()->make(ConfigurationManager::class);
+
+        $domains = $config->getDatabaseConfiguredDomains();
+
+        $this->assertContains('youtube.com', $domains, 'Pasted URL should normalize to a bare lowercase host');
+        $this->assertContains('github.com', $domains, 'Surrounding whitespace should be trimmed');
     }
 
     #[Test]
@@ -319,8 +351,8 @@ class ContentFilterConfigurationTest extends TestCase
     #[Test]
     public function forum_domain_is_automatically_allowlisted()
     {
-        $this->setting('forum_url', 'https://myforum.com/forum');
-
+        // The forum's base URL lives in config.php (exposed via Flarum\Foundation\Config),
+        // not the settings table. The integration test harness boots with http://localhost.
         $this->app();
 
         /** @var ConfigurationManager $config */
@@ -328,6 +360,6 @@ class ContentFilterConfigurationTest extends TestCase
 
         $domains = $config->getAllowedDomains();
 
-        $this->assertContains('myforum.com', $domains, 'Forum domain should be automatically allowlisted');
+        $this->assertContains('localhost', $domains, 'Forum domain should be automatically allowlisted');
     }
 }

--- a/tests/integration/ContentFilterTest.php
+++ b/tests/integration/ContentFilterTest.php
@@ -186,6 +186,41 @@ class ContentFilterTest extends TestCase
     }
 
     #[Test]
+    public function fresh_user_link_to_allowlisted_domain_is_not_flagged()
+    {
+        // Issue #22: the admin UI saves the allowlist newline-separated, but the backend used to
+        // json_decode it, so any UI-configured allowlist was silently ignored and every external
+        // link from a monitored user was flagged. Configure the allowlist exactly as the UI does.
+        $this->setting('fof-anti-spam.content-filter.allowed_domains', "youtube.com\nyoutu.be");
+        $this->setting('fof-anti-spam.content-filter.flag_threshold', 20);
+        $this->setting('fof-anti-spam.content-filter.spam_threshold', 20);
+
+        $response = $this->send(
+            $this->request('POST', '/api/discussions', [
+                'authenticatedAs' => 3,
+                'json' => [
+                    'data' => [
+                        'type' => 'discussions',
+                        'attributes' => [
+                            'title' => 'My introduction',
+                            'content' => 'Check https://youtube.com/@unetouchedharmonie for my channel',
+                        ],
+                    ],
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $post = Post::where('user_id', 3)->orderBy('id', 'desc')->first();
+        $this->assertNotNull($post, 'Post should be created');
+
+        $flag = Flag::where('post_id', $post->id)->where('type', 'spam')->first();
+        $this->assertNull($flag, 'A link to an allowlisted domain should not be flagged');
+        $this->assertNotFalse($post->is_approved, 'Post to an allowlisted domain should not be unapproved');
+    }
+
+    #[Test]
     public function old_user_with_many_posts_is_not_monitored()
     {
         $this->app();


### PR DESCRIPTION
Fixes #22.

## Problem
The admin-UI domain allowlist was silently ignored — every external link from a monitored (fresh / low-post) user was flagged regardless of what was configured. Two causes:

1. **Format mismatch.** The admin textarea saves one domain per line, but `ConfigurationManager` ran the value through `json_decode` and discarded non-arrays. `json_decode` of newline text returns `null`, so the DB allowlist collapsed to `[]` with no error. (The sibling `blocked_words` already parses line-wise — `allowed_domains` was the outlier.)
2. **`forum_url` is not a setting.** The forum's own domain was read from `settings->get('forum_url')`, but Flarum stores the base URL in `config.php`, so the documented auto-allowlisting never happened either.

With default thresholds a single URL scores 50, so a legit newcomer linking to an allowlisted domain — even the forum itself — got flagged/unapproved.

## Fix
- Parse the setting **newline-separated** via a `parseDomainList()` helper, with a JSON-array fallback for installs that hand-wrote one to work around this.
- Read the forum domain from **`Flarum\Foundation\Config::url()->getHost()`** (`config.php`); inject `Config` into `ConfigurationManager`.
- **Normalize** entries to bare lowercase hosts so pasted `https://YouTube.com/` matches the detector. Extracted the extender's private `normalizeDomain()` to a shared `ConfigurationManager::normalizeDomain()`; the extender now delegates to it.

## Tests (TDD)
- `fresh_user_link_to_allowlisted_domain_is_not_flagged` — end-to-end repro: fresh user posts an allowlisted link configured **newline-style** (as the UI saves it); written failing first.
- Updated the two tests that had encoded the bugs (`domain_allowlist_merges_code_and_database` → newline format; `forum_domain_is_automatically_allowlisted` → real `Config` URL).
- Added JSON backward-compat and pasted/uppercase normalization cases.
- Full suite (71 tests) + PHPStan green locally on both SQLite and MySQL.
