### PR TITLE
[2.x] feat: Clear user bio when marking a user as spammer

### DIFF
--- a/src/Command/MarkUserAsSpammerHandler.php
+++ b/src/Command/MarkUserAsSpammerHandler.php
@@ -121,16 +121,25 @@ class MarkUserAsSpammerHandler
         if ($this->deleteUser) {
             // Direct deletion - events fire via Eloquent model
             $user->delete();
-        } elseif ($this->extensions->isEnabled('flarum-suspend') && $user->suspended_until === null) {
+
+            return;
+        }
+
+        // Spammers often hide spam in their bio, which moderators easily miss. Clear it when
+        // fof/user-bio is enabled (the bio column it adds to the users table).
+        if ($this->extensions->isEnabled('fof-user-bio') && ! empty($user->bio)) {
+            $user->bio = null;
+            $user->save();
+        }
+
+        if ($this->extensions->isEnabled('flarum-suspend') && $user->suspended_until === null) {
             // Direct property update - events fire when model is saved
             $user->suspended_until = Carbon::now()->addYears(20);
             $user->save();
         }
 
-        if (! $this->deleteUser) {
-            $user->refreshDiscussionCount();
-            $user->refreshCommentCount();
-        }
+        $user->refreshDiscussionCount();
+        $user->refreshCommentCount();
     }
 
     /**

--- a/tests/integration/SpamblockTest.php
+++ b/tests/integration/SpamblockTest.php
@@ -337,4 +337,62 @@ class SpamblockTest extends TestCase
         // Verify user is deleted
         $this->assertNull(User::find(5), 'User should be deleted');
     }
+
+    #[Test]
+    public function spammer_bio_is_cleared_when_user_bio_is_enabled()
+    {
+        $this->extension('fof-user-bio');
+
+        $this->app();
+
+        $user = User::find(5);
+        $user->bio = 'Buy cheap pills at spam.example';
+        $user->save();
+
+        $this->assertSame('Buy cheap pills at spam.example', User::find(5)->bio, 'Spammer should start with a bio');
+
+        $response = $this->send(
+            $this->request('POST', 'api/users/5/spamblock', [
+                'authenticatedAs' => 3,
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertNull(User::find(5)->bio, 'Spammer bio should be cleared');
+    }
+
+    #[Test]
+    public function spamblock_works_without_user_bio_extension()
+    {
+        // fof-user-bio is not enabled here; spamblock must not error.
+        $response = $this->send(
+            $this->request('POST', 'api/users/5/spamblock', [
+                'authenticatedAs' => 3,
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function deleting_spammer_with_bio_does_not_error()
+    {
+        $this->extension('fof-user-bio');
+        $this->setting('fof-anti-spam.actions.deleteUser', true);
+
+        $this->app();
+
+        $user = User::find(5);
+        $user->bio = 'Buy cheap pills at spam.example';
+        $user->save();
+
+        $response = $this->send(
+            $this->request('POST', 'api/users/5/spamblock', [
+                'authenticatedAs' => 3,
+            ])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertNull(User::find(5), 'User should be deleted');
+    }
 }


### PR DESCRIPTION
Closes #11.

Spammers often hide spam in their [fof/user-bio](https://github.com/FriendsOfFlarum/user-bio) bio, which moderators easily miss. The old spamblock extension cleared it when marking a user as a spammer; this restores that.

## Change
In `MarkUserAsSpammerHandler::handleUser()`, when the user isn't being deleted and `fof-user-bio` is enabled, clear `$user->bio` (the column that extension adds to the `users` table). Always-on, no setting — matching the previous behaviour. Added an early return on the delete path, which also removed the duplicated `! deleteUser` guards.

No `BioChanged` event is fired (keeps anti-spam decoupled from user-bio internals; the action is already covered by the `user.marked_as_spammer` audit log).

## Tests (TDD)
- `spammer_bio_is_cleared_when_user_bio_is_enabled` — bio is null after spamblock (written failing first).
- `spamblock_works_without_user_bio_extension` — no error when the extension is disabled.
- `deleting_spammer_with_bio_does_not_error` — the deleteUser path still works with a bio set.
- Full suite (74 tests) + PHPStan green locally on both SQLite and MySQL.
